### PR TITLE
Add missing distance tests and imports

### DIFF
--- a/tests/distance.test.ts
+++ b/tests/distance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { pairwiseDistances } from '../src/distance';
+import { minutesAtMph, buildMatrix, Coordinate } from '../src/distance';
 
 describe('pairwiseDistances', () => {
   it('computes distances when all coordinates are present', () => {
@@ -24,6 +25,8 @@ describe('pairwiseDistances', () => {
     expect(() => pairwiseDistances(ids, idToCoord)).toThrow(
       'Missing coordinates for id "b"'
     );
+  });
+});
 
 describe('minutesAtMph', () => {
   it('throws on zero mph', () => {
@@ -33,6 +36,7 @@ describe('minutesAtMph', () => {
   it('throws on negative mph', () => {
     expect(() => minutesAtMph(1, -5)).toThrow('greater than 0');
   });
+});
 
 describe('buildMatrix', () => {
   const coords: Coordinate[] = [


### PR DESCRIPTION
## Summary
- fix incomplete `pairwiseDistances` tests by closing blocks and importing needed utilities
- test `minutesAtMph` error handling
- verify `buildMatrix` symmetry and zero diagonal

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bbd9a660832897196e5b50ee55c4