### PR TITLE
feat: add basic CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+
+export const program = new Command();
+
+program
+  .name('rustbelt')
+  .description('CLI for ...')
+  .version('0.1.0');
+
+export function run(argv: readonly string[] = process.argv): Command {
+  program.parse(argv as string[]);
+  return program;
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  run();
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { run, program } from '../src/index';
+
+describe('CLI', () => {
+  it('configures the commander program', () => {
+    run(['node', 'rustbelt']);
+    expect(program.name()).toBe('rustbelt');
+    expect(program.description()).toBe('CLI for ...');
+    expect(program.version()).toBe('0.1.0');
+  });
+});


### PR DESCRIPTION
## Summary
- add commander CLI entry point with run helper
- test CLI configuration

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bfc5fd1883289bd3c12cddf05f80