### PR TITLE
chore: migrate to flat eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,34 @@
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import prettier from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['dist', 'node_modules'],
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
+    },
+  },
+  prettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "seedrandom": "^3.0.5"
       },
       "devDependencies": {
+        "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^9.33.0",
+        "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.6.2",
         "tsx": "^4.20.4",
         "typescript": "^5.9.2",
@@ -1072,6 +1074,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
@@ -1796,6 +1808,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3006,6 +3034,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,18 @@
   },
   "dependencies": {
     "commander": "^14.0.0",
-    "seedrandom": "^3.0.5",
-    "open-location-code": "^1.0.3"
+    "open-location-code": "^1.0.3",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
-    "typescript": "^5.9.2",
-    "tsx": "^4.20.4",
-    "eslint": "^9.33.0",
-    "@typescript-eslint/parser": "^8.40.0",
+    "@types/node": "^24.3.0",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
+    "@typescript-eslint/parser": "^8.40.0",
+    "eslint": "^9.33.0",
+    "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.6.2",
+    "tsx": "^4.20.4",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   }
 }

--- a/src/distance.ts
+++ b/src/distance.ts
@@ -1,4 +1,4 @@
-export type Coord = [number, number];
+export type Coord = readonly [number, number];
 
 /**
  * Compute pairwise Euclidean distances between a list of IDs.
@@ -45,7 +45,7 @@ export function minutesAtMph(distance: number, mph: number): number {
   return (distance / mph) * 60;
 }
 
-export type Coordinate = [number, number];
+export type Coordinate = readonly [number, number];
 
 // Haversine formula to compute great-circle distance between two points on Earth in miles
 function haversineMiles(a: Coordinate, b: Coordinate): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,70 @@
+export type ID = string;
+
+export type Coord = readonly [number, number];
+
+export interface Anchor {
+  id: ID;
+  name: string;
+  coord: Coord;
+}
+
+export interface Store {
+  id: ID;
+  name: string;
+  coord: Coord;
+  dwellMin?: number;
+  score?: number; // v0.3
+  tags?: string[];
+  dayId?: string; // when using a global list
+}
+
+export type LockSpec =
+  | { storeId: ID; position: "firstAfterStart" | "lastBeforeEnd" }
+  | { storeId: ID; index: number }
+  | { storeId: ID; afterStoreId: ID };
+
+export interface DayConfig {
+  dayId: string;
+  start: Anchor;
+  end: Anchor;
+  window: { start: string; end: string }; // "HH:mm"
+  mph?: number;
+  defaultDwellMin?: number;
+  mustVisitIds?: ID[];
+  locks?: LockSpec[]; // v0.2+
+}
+
+export interface TripConfig {
+  mph?: number;
+  defaultDwellMin?: number;
+  seed?: number;
+  snapDuplicateToleranceMeters?: number;
+}
+
+export interface Leg {
+  fromId: ID;
+  toId: ID;
+  driveMin: number;
+  distanceMi: number;
+}
+
+export interface StopPlan {
+  id: ID;
+  type: "start" | "store" | "end";
+  arrive: string;
+  depart: string;
+  dwellMin?: number;
+  legIn?: Leg;
+}
+
+export interface DayPlan {
+  dayId: string;
+  stops: StopPlan[];
+  metrics: {
+    storesVisited: number;
+    totalDriveMin: number;
+    totalDwellMin: number;
+    slackMin: number;
+  };
+}
+


### PR DESCRIPTION
## Summary
- replace `.eslintrc` with ESLint v9 flat config that applies `@typescript-eslint` recommendations and disables Prettier conflicts
- add `eslint-config-prettier` as a dev dependency
- accept readonly coordinate tuples and update planning types
- add Node.js type definitions so `process` references compile

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2c406b883288ad4386c9690a659