### PR TITLE
feat: add schedule timeline utilities

### DIFF
--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,0 +1,137 @@
+import { minutesAtMph } from './distance';
+import type {
+  Anchor,
+  Store,
+  ID,
+  Coord,
+  StopPlan,
+} from './types';
+
+export interface ScheduleCtx {
+  start: Anchor;
+  end: Anchor;
+  window: { start: string; end: string };
+  mph: number;
+  defaultDwellMin: number;
+  stores: Record<ID, Store>;
+  mustVisitIds?: ID[];
+}
+
+export interface TimelineResult {
+  stops: StopPlan[];
+  totalDriveMin: number;
+  totalDwellMin: number;
+  hotelETAmin: number;
+}
+
+function hhmmToMin(time: string): number {
+  const [hh, mm] = time.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+function minToHhmm(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = Math.round(min % 60);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function distanceMiles(a: Coord, b: Coord): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return Math.hypot(dx, dy);
+}
+
+export function computeTimeline(order: ID[], ctx: ScheduleCtx): TimelineResult {
+  const startMin = hhmmToMin(ctx.window.start);
+  const stops: StopPlan[] = [];
+
+  let totalDriveMin = 0;
+  let totalDwellMin = 0;
+  let currentTime = startMin;
+  let currentId: ID = ctx.start.id;
+  let currentCoord: Coord = ctx.start.coord;
+
+  // start stop
+  stops.push({
+    id: ctx.start.id,
+    type: 'start',
+    arrive: minToHhmm(currentTime),
+    depart: minToHhmm(currentTime),
+  });
+
+  for (const id of order) {
+    const store = ctx.stores[id];
+    if (!store) {
+      throw new Error(`Unknown store id: ${id}`);
+    }
+
+    const dist = distanceMiles(currentCoord, store.coord);
+    const driveMin = minutesAtMph(dist, ctx.mph);
+    currentTime += driveMin;
+    totalDriveMin += driveMin;
+
+    const dwell = store.dwellMin ?? ctx.defaultDwellMin;
+    const arriveMin = currentTime;
+    currentTime += dwell;
+    totalDwellMin += dwell;
+
+    stops.push({
+      id: store.id,
+      type: 'store',
+      arrive: minToHhmm(arriveMin),
+      depart: minToHhmm(currentTime),
+      dwellMin: dwell,
+      legIn: {
+        fromId: currentId,
+        toId: store.id,
+        driveMin,
+        distanceMi: dist,
+      },
+    });
+
+    currentId = store.id;
+    currentCoord = store.coord;
+  }
+
+  // leg to end
+  const dist = distanceMiles(currentCoord, ctx.end.coord);
+  const driveMin = minutesAtMph(dist, ctx.mph);
+  currentTime += driveMin;
+  totalDriveMin += driveMin;
+
+  stops.push({
+    id: ctx.end.id,
+    type: 'end',
+    arrive: minToHhmm(currentTime),
+    depart: minToHhmm(currentTime),
+    legIn: {
+      fromId: currentId,
+      toId: ctx.end.id,
+      driveMin,
+      distanceMi: dist,
+    },
+  });
+
+  return { stops, totalDriveMin, totalDwellMin, hotelETAmin: currentTime };
+}
+
+export function isFeasible(order: ID[], ctx: ScheduleCtx): boolean {
+  if (ctx.mustVisitIds) {
+    for (const id of ctx.mustVisitIds) {
+      if (!order.includes(id)) {
+        return false;
+      }
+    }
+  }
+
+  const { hotelETAmin } = computeTimeline(order, ctx);
+  const endMin = hhmmToMin(ctx.window.end);
+  return hotelETAmin <= endMin;
+}
+
+export function slackMin(order: ID[], ctx: ScheduleCtx): number {
+  const { hotelETAmin } = computeTimeline(order, ctx);
+  const endMin = hhmmToMin(ctx.window.end);
+  return Math.max(0, endMin - hotelETAmin);
+}
+


### PR DESCRIPTION
## Summary
- add ScheduleCtx and timeline helpers for route planning
- compute per-stop arrival/departure times using minutesAtMph
- expose feasibility and slack utilities for solvers

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier' imported from eslint.config.js)*
- `npm run build` *(fails: Cannot find name 'process'. Do you need to install type definitions for node?)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3296f4c83288b29ff23092e4eae