### PR TITLE
Add heuristic planner with greedy insertion and local search

### DIFF
--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -1,0 +1,160 @@
+import seedrandom from 'seedrandom';
+import {
+  computeTimeline,
+  isFeasible,
+  slackMin,
+  ScheduleCtx,
+} from './schedule';
+import type { ID, Coord } from './types';
+
+function distance(a: Coord, b: Coord): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return Math.hypot(dx, dy);
+}
+
+export interface HeuristicCtx extends ScheduleCtx {
+  candidateIds: ID[];
+  seed?: number;
+}
+
+export function planDay(ctx: HeuristicCtx): ID[] {
+  const rng = seedrandom(String(ctx.seed ?? 0));
+  const order = seedMustVisits(ctx, rng);
+  const remaining = ctx.candidateIds.filter((id) => !order.includes(id));
+  greedyInsert(order, remaining, ctx, rng);
+  twoOpt(order, ctx);
+  relocate(order, ctx);
+  return order;
+}
+
+function seedMustVisits(
+  ctx: HeuristicCtx,
+  rng: seedrandom.PRNG,
+): ID[] {
+  const { mustVisitIds } = ctx;
+  if (!mustVisitIds || mustVisitIds.length === 0) return [];
+  const remaining = mustVisitIds.filter((id) => ctx.stores[id]);
+  const order: ID[] = [];
+  let currentCoord = ctx.start.coord;
+  while (remaining.length > 0) {
+    let bestDist = Infinity;
+    const bestIds: ID[] = [];
+    for (const id of remaining) {
+      const dist = distance(currentCoord, ctx.stores[id].coord);
+      if (dist < bestDist - 1e-9) {
+        bestDist = dist;
+        bestIds.length = 0;
+        bestIds.push(id);
+      } else if (Math.abs(dist - bestDist) < 1e-9) {
+        bestIds.push(id);
+      }
+    }
+    const pick = bestIds[Math.floor(rng() * bestIds.length)];
+    order.push(pick);
+    currentCoord = ctx.stores[pick].coord;
+    remaining.splice(remaining.indexOf(pick), 1);
+  }
+  return order;
+}
+
+function greedyInsert(
+  order: ID[],
+  remaining: ID[],
+  ctx: ScheduleCtx,
+  rng: seedrandom.PRNG,
+): void {
+  while (remaining.length > 0) {
+    const base = computeTimeline(order, ctx);
+    const baseEta = base.hotelETAmin;
+    let bestId: ID | null = null;
+    let bestPos = -1;
+    let bestDelta = Infinity;
+    let bestSlack = -Infinity;
+    let bestDrive = Infinity;
+    for (const id of remaining) {
+      for (let pos = 0; pos <= order.length; pos++) {
+        const candidate = order.slice();
+        candidate.splice(pos, 0, id);
+        if (!isFeasible(candidate, ctx)) continue;
+        const t = computeTimeline(candidate, ctx);
+        const delta = t.hotelETAmin - baseEta;
+        const slack = slackMin(candidate, ctx);
+        if (
+          delta < bestDelta - 1e-9 ||
+          (Math.abs(delta - bestDelta) < 1e-9 &&
+            (slack > bestSlack + 1e-9 ||
+              (Math.abs(slack - bestSlack) < 1e-9 &&
+                (t.totalDriveMin < bestDrive - 1e-9 ||
+                  (Math.abs(t.totalDriveMin - bestDrive) < 1e-9 &&
+                    rng() < 0.5)))))
+        ) {
+          bestId = id;
+          bestPos = pos;
+          bestDelta = delta;
+          bestSlack = slack;
+          bestDrive = t.totalDriveMin;
+        }
+      }
+    }
+    if (bestId == null) break;
+    order.splice(bestPos, 0, bestId);
+    remaining.splice(remaining.indexOf(bestId), 1);
+  }
+}
+
+function twoOpt(order: ID[], ctx: ScheduleCtx): void {
+  let improved = true;
+  while (improved) {
+    improved = false;
+    const baseSlack = slackMin(order, ctx);
+    const baseDrive = computeTimeline(order, ctx).totalDriveMin;
+    outer: for (let i = 0; i < order.length - 1; i++) {
+      for (let j = i + 1; j < order.length; j++) {
+        const candidate = order.slice();
+        const segment = candidate.slice(i, j + 1).reverse();
+        candidate.splice(i, segment.length, ...segment);
+        if (!isFeasible(candidate, ctx)) continue;
+        const slack = slackMin(candidate, ctx);
+        const drive = computeTimeline(candidate, ctx).totalDriveMin;
+        if (slack > baseSlack + 1e-9 ||
+          (Math.abs(slack - baseSlack) < 1e-9 && drive < baseDrive - 1e-9)
+        ) {
+          order.splice(0, order.length, ...candidate);
+          improved = true;
+          break outer;
+        }
+      }
+    }
+  }
+}
+
+function relocate(order: ID[], ctx: ScheduleCtx): void {
+  let improved = true;
+  while (improved) {
+    improved = false;
+    const baseSlack = slackMin(order, ctx);
+    const baseDrive = computeTimeline(order, ctx).totalDriveMin;
+    outer: for (let i = 0; i < order.length; i++) {
+      const id = order[i];
+      const removed = order.slice();
+      removed.splice(i, 1);
+      for (let j = 0; j <= removed.length; j++) {
+        if (j === i) continue;
+        const candidate = removed.slice();
+        candidate.splice(j, 0, id);
+        if (!isFeasible(candidate, ctx)) continue;
+        const slack = slackMin(candidate, ctx);
+        const drive = computeTimeline(candidate, ctx).totalDriveMin;
+        if (slack > baseSlack + 1e-9 ||
+          (Math.abs(slack - baseSlack) < 1e-9 && drive < baseDrive - 1e-9)
+        ) {
+          order.splice(0, order.length, ...candidate);
+          improved = true;
+          break outer;
+        }
+      }
+    }
+  }
+}
+

--- a/tests/heuristics.test.ts
+++ b/tests/heuristics.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { planDay } from '../src/heuristics';
+import type { HeuristicCtx } from '../src/heuristics';
+
+describe('heuristics', () => {
+  function buildCtx(): HeuristicCtx {
+    return {
+      start: { id: 'S', name: 'start', coord: [0, 0] },
+      end: { id: 'E', name: 'end', coord: [10, 0] },
+      window: { start: '00:00', end: '23:59' },
+      mph: 60,
+      defaultDwellMin: 0,
+      stores: {
+        A: { id: 'A', name: 'A', coord: [2, 0] },
+        B: { id: 'B', name: 'B', coord: [5, 0] },
+        C: { id: 'C', name: 'C', coord: [8, 0] },
+      },
+      mustVisitIds: ['B'],
+      candidateIds: ['A', 'B', 'C'],
+      seed: 1,
+    };
+  }
+
+  it('seeds must-visits and inserts greedily', () => {
+    const ctx = buildCtx();
+    const order = planDay(ctx);
+    expect(order).toEqual(['A', 'B', 'C']);
+  });
+
+  it('is deterministic with fixed seed', () => {
+    const ctx1 = buildCtx();
+    const ctx2 = buildCtx();
+    const a = planDay(ctx1);
+    const b = planDay(ctx2);
+    expect(a).toEqual(b);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement heuristic day planner with must-visit seeding
- add greedy insertion with slack/drive tie-breaking and RNG seed
- apply 2-opt and relocate local search improvements
- test seeding and deterministic behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a903706b9c83289d3a901fceafb719