### PR TITLE
feat: add solve-day CLI

### DIFF
--- a/fixtures/simple-trip.json
+++ b/fixtures/simple-trip.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "mph": 60,
+    "defaultDwellMin": 0,
+    "seed": 1
+  },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "E", "name": "end", "lat": 10, "lon": 0 },
+      "window": { "start": "00:00", "end": "23:59" },
+      "mustVisitIds": ["B"]
+    }
+  ],
+  "stores": [
+    { "id": "A", "name": "A", "lat": 2, "lon": 0 },
+    { "id": "B", "name": "B", "lat": 5, "lon": 0 },
+    { "id": "C", "name": "C", "lat": 8, "lon": 0 }
+  ]
+}

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { parseTrip } from '../io/parse';
+import { planDay } from '../heuristics';
+import { computeTimeline, slackMin } from '../schedule';
+import { emitItinerary, EmitResult } from '../io/emit';
+import type { ID, Store, DayPlan } from '../types';
+
+export interface SolveDayOptions {
+  tripPath: string;
+  dayId: string;
+  mph?: number;
+  defaultDwellMin?: number;
+  seed?: number;
+}
+
+export function solveDay(opts: SolveDayOptions): EmitResult {
+  const raw = readFileSync(opts.tripPath, 'utf8');
+  const json = JSON.parse(raw);
+  const trip = parseTrip(json);
+
+  const day = trip.days.find((d) => d.dayId === opts.dayId);
+  if (!day) {
+    throw new Error(`Day not found: ${opts.dayId}`);
+  }
+
+  const mph = opts.mph ?? day.mph ?? trip.config.mph ?? 30;
+  const defaultDwellMin =
+    opts.defaultDwellMin ??
+    day.defaultDwellMin ??
+    trip.config.defaultDwellMin ??
+    0;
+
+  const stores: Record<ID, Store> = {};
+  const candidateIds: ID[] = [];
+  for (const s of trip.stores) {
+    if (!s.dayId || s.dayId === day.dayId) {
+      stores[s.id] = s;
+      candidateIds.push(s.id);
+    }
+  }
+
+  const ctx = {
+    start: day.start,
+    end: day.end,
+    window: day.window,
+    mph,
+    defaultDwellMin,
+    stores,
+    mustVisitIds: day.mustVisitIds,
+    candidateIds,
+    seed: opts.seed ?? trip.config.seed,
+  };
+
+  const order = planDay(ctx);
+  const timeline = computeTimeline(order, ctx);
+
+  const dayPlan: DayPlan = {
+    dayId: day.dayId,
+    stops: timeline.stops,
+    metrics: {
+      storesVisited: order.length,
+      totalDriveMin: timeline.totalDriveMin,
+      totalDwellMin: timeline.totalDwellMin,
+      slackMin: slackMin(order, ctx),
+    },
+  };
+
+  return emitItinerary([dayPlan]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { solveDay } from './app/solveDay';
 
 export const program = new Command();
 
@@ -6,6 +7,28 @@ program
   .name('rustbelt')
   .description('CLI for ...')
   .version('0.1.0');
+
+program
+  .command('solve-day')
+  .requiredOption('--trip <file>', 'Path to trip JSON file')
+  .requiredOption('--day <id>', 'Day id to solve')
+  .option('--mph <mph>', 'Average speed in mph', parseFloat)
+  .option(
+    '--default-dwell <min>',
+    'Default dwell minutes',
+    parseFloat,
+  )
+  .option('--seed <seed>', 'Random seed', parseFloat)
+  .action((opts) => {
+    const result = solveDay({
+      tripPath: opts.trip,
+      dayId: opts.day,
+      mph: opts.mph,
+      defaultDwellMin: opts.defaultDwell,
+      seed: opts.seed,
+    });
+    console.log(result.json);
+  });
 
 export function run(argv: readonly string[] = process.argv): Command {
   program.parse(argv as string[]);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { run, program } from '../src/index';
+import { program } from '../src/index';
 
 describe('CLI', () => {
   it('configures the commander program', () => {
-    run(['node', 'rustbelt']);
     expect(program.name()).toBe('rustbelt');
     expect(program.description()).toBe('CLI for ...');
     expect(program.version()).toBe('0.1.0');
+    expect(program.commands.map((c) => c.name())).toContain('solve-day');
   });
 });

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { solveDay } from '../src/app/solveDay';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('solveDay', () => {
+  it('produces a day plan for a simple trip', () => {
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    const ids = data.days[0].stops.map((s: { id: string }) => s.id);
+    expect(ids).toEqual(['S', 'A', 'B', 'C', 'E']);
+    expect(data.days[0].metrics.storesVisited).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `solveDay` orchestrator for single-day itineraries
- expose `solve-day` command via Commander CLI
- add tests and sample trip fixture

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90682a6048328a466cc723b85fc1b