### PR TITLE
Use haversine distance for scheduling

### DIFF
--- a/src/distance.ts
+++ b/src/distance.ts
@@ -48,7 +48,7 @@ export function minutesAtMph(distance: number, mph: number): number {
 export type Coordinate = readonly [number, number];
 
 // Haversine formula to compute great-circle distance between two points on Earth in miles
-function haversineMiles(a: Coordinate, b: Coordinate): number {
+export function haversineMiles(a: Coordinate, b: Coordinate): number {
   const toRad = (deg: number) => (deg * Math.PI) / 180;
   const [lat1, lon1] = a.map(toRad) as [number, number];
   const [lat2, lon2] = b.map(toRad) as [number, number];

--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -5,13 +5,8 @@ import {
   slackMin,
   ScheduleCtx,
 } from './schedule';
-import type { ID, Coord } from './types';
-
-function distance(a: Coord, b: Coord): number {
-  const dx = a[0] - b[0];
-  const dy = a[1] - b[1];
-  return Math.hypot(dx, dy);
-}
+import { haversineMiles } from './distance';
+import type { ID } from './types';
 
 export interface HeuristicCtx extends ScheduleCtx {
   candidateIds: ID[];
@@ -41,7 +36,7 @@ function seedMustVisits(
     let bestDist = Infinity;
     const bestIds: ID[] = [];
     for (const id of remaining) {
-      const dist = distance(currentCoord, ctx.stores[id].coord);
+      const dist = haversineMiles(currentCoord, ctx.stores[id].coord);
       if (dist < bestDist - 1e-9) {
         bestDist = dist;
         bestIds.length = 0;

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,4 +1,4 @@
-import { minutesAtMph } from './distance';
+import { minutesAtMph, haversineMiles } from './distance';
 import type {
   Anchor,
   Store,
@@ -35,18 +35,12 @@ function minToHhmm(min: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }
 
-function distanceMiles(a: Coord, b: Coord): number {
-  const dx = a[0] - b[0];
-  const dy = a[1] - b[1];
-  return Math.hypot(dx, dy);
-}
-
 function legMetrics(
   from: Coord,
   to: Coord,
   mph: number,
 ): { dist: number; driveMin: number } {
-  const dist = distanceMiles(from, to);
+  const dist = haversineMiles(from, to);
   return { dist, driveMin: minutesAtMph(dist, mph) };
 }
 

--- a/tests/synthetic-day.test.ts
+++ b/tests/synthetic-day.test.ts
@@ -5,17 +5,19 @@ import type { HeuristicCtx } from '../src/heuristics';
 import seedrandom from 'seedrandom';
 import { performance } from 'node:perf_hooks';
 
+const MILE_TO_DEG = 1 / 69; // Approximate degrees per mile at the equator
+
 function buildSyntheticCtx(): HeuristicCtx {
   return {
     start: { id: 'S', name: 'start', coord: [0, 0] },
-    end: { id: 'E', name: 'end', coord: [10, 0] },
+    end: { id: 'E', name: 'end', coord: [10 * MILE_TO_DEG, 0] },
     window: { start: '08:00', end: '18:00' },
     mph: 60,
     defaultDwellMin: 0,
     stores: {
-      A: { id: 'A', name: 'A', coord: [2, 0] },
-      B: { id: 'B', name: 'B', coord: [5, 0] },
-      C: { id: 'C', name: 'C', coord: [8, 0] },
+      A: { id: 'A', name: 'A', coord: [2 * MILE_TO_DEG, 0] },
+      B: { id: 'B', name: 'B', coord: [5 * MILE_TO_DEG, 0] },
+      C: { id: 'C', name: 'C', coord: [8 * MILE_TO_DEG, 0] },
     },
     mustVisitIds: ['B'],
     candidateIds: ['A', 'B', 'C'],
@@ -46,13 +48,20 @@ function buildRandomCtx(count: number, seed = 1): HeuristicCtx {
   const candidateIds: string[] = [];
   for (let i = 0; i < count; i++) {
     const id = `S${i}`;
-    const coord: [number, number] = [rng() * 100, rng() * 100];
+    const coord: [number, number] = [
+      rng() * 100 * MILE_TO_DEG,
+      rng() * 100 * MILE_TO_DEG,
+    ];
     stores[id] = { id, name: id, coord };
     candidateIds.push(id);
   }
   return {
     start: { id: 'S', name: 'start', coord: [0, 0] },
-    end: { id: 'E', name: 'end', coord: [100, 100] },
+    end: {
+      id: 'E',
+      name: 'end',
+      coord: [100 * MILE_TO_DEG, 100 * MILE_TO_DEG],
+    },
     window: { start: '08:00', end: '20:00' },
     mph: 60,
     defaultDwellMin: 0,


### PR DESCRIPTION
## Summary
- switch schedule and heuristics to haversine-based distance calculations
- export haversineMiles and adjust synthetic tests for geographic coords

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c2d84ca08328ac8fb32a16613bc9