### PR TITLE
Add regression fixtures and performance baseline tests

### DIFF
--- a/fixtures/clustered-candidates.json
+++ b/fixtures/clustered-candidates.json
@@ -1,0 +1,18 @@
+{
+  "config": { "mph": 60, "defaultDwellMin": 0, "seed": 1 },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "H", "name": "end", "lat": 0.145, "lon": 0 },
+      "window": { "start": "08:00", "end": "18:00" }
+    }
+  ],
+  "stores": [
+    { "id": "A", "name": "A", "lat": 0.0145, "lon": 0 },
+    { "id": "B", "name": "B", "lat": 0.029, "lon": 0 },
+    { "id": "C", "name": "C", "lat": 0.0435, "lon": 0 },
+    { "id": "D", "name": "D", "lat": 0.058, "lon": 0 },
+    { "id": "E", "name": "E", "lat": 0.0725, "lon": 0 }
+  ]
+}

--- a/fixtures/far-must-visit.json
+++ b/fixtures/far-must-visit.json
@@ -1,0 +1,17 @@
+{
+  "config": { "mph": 60, "defaultDwellMin": 0, "seed": 1 },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "H", "name": "end", "lat": 0.869, "lon": 0 },
+      "window": { "start": "08:00", "end": "10:00" },
+      "mustVisitIds": ["X"]
+    }
+  ],
+  "stores": [
+    { "id": "X", "name": "X", "lat": 0.724, "lon": 0 },
+    { "id": "A", "name": "A", "lat": 0, "lon": 1.449 },
+    { "id": "B", "name": "B", "lat": 0, "lon": -1.449 }
+  ]
+}

--- a/fixtures/scattered-candidates.json
+++ b/fixtures/scattered-candidates.json
@@ -1,0 +1,16 @@
+{
+  "config": { "mph": 60, "defaultDwellMin": 0, "seed": 1 },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "H", "name": "end", "lat": 0.145, "lon": 0 },
+      "window": { "start": "08:00", "end": "09:00" }
+    }
+  ],
+  "stores": [
+    { "id": "A", "name": "A", "lat": 0, "lon": 1.739 },
+    { "id": "B", "name": "B", "lat": 0, "lon": -1.739 },
+    { "id": "C", "name": "C", "lat": 1.739, "lon": 0 }
+  ]
+}

--- a/tests/__snapshots__/solveDay.test.ts.snap
+++ b/tests/__snapshots__/solveDay.test.ts.snap
@@ -1,0 +1,76 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
+{
+  "days": [
+    {
+      "dayId": "D1",
+      "metrics": {
+        "slackMin": 748.0590557204848,
+        "storesVisited": 3,
+        "totalDriveMin": 690.9409442795152,
+        "totalDwellMin": 0,
+      },
+      "stops": [
+        {
+          "arrive": "00:00",
+          "depart": "00:00",
+          "id": "S",
+          "type": "start",
+        },
+        {
+          "arrive": "02:18",
+          "depart": "02:18",
+          "dwellMin": 0,
+          "id": "A",
+          "legIn": {
+            "distanceMi": 138.18818885590304,
+            "driveMin": 138.18818885590304,
+            "fromId": "S",
+            "toId": "A",
+          },
+          "type": "store",
+        },
+        {
+          "arrive": "05:45",
+          "depart": "05:45",
+          "dwellMin": 0,
+          "id": "B",
+          "legIn": {
+            "distanceMi": 207.28228328385455,
+            "driveMin": 207.28228328385455,
+            "fromId": "A",
+            "toId": "B",
+          },
+          "type": "store",
+        },
+        {
+          "arrive": "09:13",
+          "depart": "09:13",
+          "dwellMin": 0,
+          "id": "C",
+          "legIn": {
+            "distanceMi": 207.28228328385458,
+            "driveMin": 207.28228328385458,
+            "fromId": "B",
+            "toId": "C",
+          },
+          "type": "store",
+        },
+        {
+          "arrive": "11:31",
+          "depart": "11:31",
+          "id": "E",
+          "legIn": {
+            "distanceMi": 138.188188855903,
+            "driveMin": 138.188188855903,
+            "fromId": "C",
+            "toId": "E",
+          },
+          "type": "end",
+        },
+      ],
+    },
+  ],
+}
+`;

--- a/tests/fixture-datasets.test.ts
+++ b/tests/fixture-datasets.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { solveDay } from '../src/app/solveDay';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('fixture datasets', () => {
+  it('clustered candidates yield many visits', () => {
+    const tripPath = join(__dirname, '../fixtures/clustered-candidates.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    expect(data.days[0].metrics.storesVisited).toBe(5);
+  });
+
+  it('scattered candidates yield no visits', () => {
+    const tripPath = join(__dirname, '../fixtures/scattered-candidates.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    expect(data.days[0].metrics.storesVisited).toBe(0);
+  });
+
+  it('far must-visit allows only the required stop', () => {
+    const tripPath = join(__dirname, '../fixtures/far-must-visit.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    expect(data.days[0].metrics.storesVisited).toBe(1);
+  });
+});

--- a/tests/schedule.test.ts
+++ b/tests/schedule.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeTimeline, slackMin } from '../src/schedule';
+import type { ScheduleCtx } from '../src/schedule';
+
+function buildCtx(): ScheduleCtx {
+  return {
+    start: { id: 'S', name: 'start', coord: [0, 0] },
+    end: { id: 'E', name: 'end', coord: [10, 0] },
+    window: { start: '00:00', end: '23:59' },
+    mph: 60,
+    defaultDwellMin: 0,
+    stores: {
+      A: { id: 'A', name: 'A', coord: [5, 0] },
+    },
+  };
+}
+
+function hhmmToMin(time: string): number {
+  const [hh, mm] = time.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+describe('schedule utilities', () => {
+  it('computeTimeline yields monotonic stop times', () => {
+    const ctx = buildCtx();
+    const timeline = computeTimeline(['A'], ctx);
+    let last = 0;
+    for (const stop of timeline.stops) {
+      const arrive = hhmmToMin(stop.arrive);
+      const depart = hhmmToMin(stop.depart);
+      expect(arrive).toBeGreaterThanOrEqual(last);
+      expect(depart).toBeGreaterThanOrEqual(arrive);
+      last = depart;
+    }
+  });
+
+  it('slackMin is never negative', () => {
+    const ctx = buildCtx();
+    // Tighten the window so arrival exceeds the end time
+    const tightCtx: ScheduleCtx = {
+      ...ctx,
+      window: { start: '00:00', end: '00:05' },
+    };
+    const slack = slackMin(['A'], tightCtx);
+    expect(slack).toBe(0);
+  });
+});

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -25,6 +25,12 @@ describe('solveDay', () => {
     expect(data.days[0].metrics.storesVisited).toBe(3);
   });
 
+  it('produces stable itinerary output (FR-31)', () => {
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    expect(JSON.parse(result.json)).toMatchSnapshot();
+  });
+
   it('throws if must visits exceed day window', () => {
     const tripPath = join(
       __dirname,

--- a/tests/synthetic-day.test.ts
+++ b/tests/synthetic-day.test.ts
@@ -86,5 +86,19 @@ describe('performance', () => {
     },
     { timeout: 30000 }
   );
+
+  it(
+    'scales to very large candidate sets',
+    () => {
+      const ctx = buildRandomCtx(300, 456);
+      const start = performance.now();
+      const order = planDay(ctx);
+      const duration = performance.now() - start;
+      expect(isFeasible(order, ctx)).toBe(true);
+      expect(order.length).toBeLessThanOrEqual(ctx.candidateIds.length);
+      expect(duration).toBeLessThan(60000);
+    },
+    { timeout: 120000 }
+  );
 });
 


### PR DESCRIPTION
## Summary
- add schedule tests ensuring timeline monotonicity and non-negative slack
- create clustered/scattered/far-must-visit fixtures with store-count assertions
- extend synthetic-day tests with 300-candidate performance check and snapshot canonical itinerary

## Testing
- `npx vitest run tests/solveDay.test.ts tests/schedule.test.ts tests/fixture-datasets.test.ts`
- `npx vitest run` *(fails: terminated after performance test exceeded environment time)*

------
https://chatgpt.com/codex/tasks/task_e_68aa00a542c4832883049337219584fe