### PR TITLE
Add name field to StopPlan and populate schedule names

### DIFF
--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -787,7 +787,15 @@ export interface TripInput { config: TripConfig; days: DayConfig\[\]; stores: St
 
 export interface Leg { fromId: ID; toId: ID; driveMin: number; distanceMi: number; }
 
-export interface StopPlan { id: ID; type: "start" | "store" | "end"; arrive: string; depart: string; dwellMin?: number; legIn?: Leg; }
+export interface StopPlan {
+  id: ID;
+  name: string;
+  type: "start" | "store" | "end";
+  arrive: string;
+  depart: string;
+  dwellMin?: number;
+  legIn?: Leg;
+}
 
 export interface DayPlan {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export function run(argv: readonly string[] = process.argv): Command {
   return program;
 }
 
-import { pathToFileURL, fileURLToPath } from 'node:url';
+import { fileURLToPath } from 'node:url';
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   run();

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -57,6 +57,7 @@ export function computeTimeline(order: ID[], ctx: ScheduleCtx): TimelineResult {
   // start stop
   stops.push({
     id: ctx.start.id,
+    name: ctx.start.name,
     type: 'start',
     arrive: minToHhmm(currentTime),
     depart: minToHhmm(currentTime),
@@ -83,6 +84,7 @@ export function computeTimeline(order: ID[], ctx: ScheduleCtx): TimelineResult {
 
     stops.push({
       id: store.id,
+      name: store.name,
       type: 'store',
       arrive: minToHhmm(arriveMin),
       depart: minToHhmm(currentTime),
@@ -110,6 +112,7 @@ export function computeTimeline(order: ID[], ctx: ScheduleCtx): TimelineResult {
 
   stops.push({
     id: ctx.end.id,
+    name: ctx.end.name,
     type: 'end',
     arrive: minToHhmm(currentTime),
     depart: minToHhmm(currentTime),

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface Leg {
 
 export interface StopPlan {
   id: ID;
+  name: string;
   type: "start" | "store" | "end";
   arrive: string;
   depart: string;

--- a/tests/__snapshots__/solveDay.test.ts.snap
+++ b/tests/__snapshots__/solveDay.test.ts.snap
@@ -16,6 +16,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
           "arrive": "00:00",
           "depart": "00:00",
           "id": "S",
+          "name": "start",
           "type": "start",
         },
         {
@@ -29,6 +30,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
             "fromId": "S",
             "toId": "A",
           },
+          "name": "A",
           "type": "store",
         },
         {
@@ -42,6 +44,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
             "fromId": "A",
             "toId": "B",
           },
+          "name": "B",
           "type": "store",
         },
         {
@@ -55,6 +58,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
             "fromId": "B",
             "toId": "C",
           },
+          "name": "C",
           "type": "store",
         },
         {
@@ -67,6 +71,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
             "fromId": "C",
             "toId": "E",
           },
+          "name": "end",
           "type": "end",
         },
       ],


### PR DESCRIPTION
## Summary
- include `name` on `StopPlan` entries
- propagate store and anchor names when building timelines
- update tests, docs, and snapshots

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad091119988328b9297bf90e7008d5