### PR TITLE
feat: add KML output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/open-location-code": "^1.0.1",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
+        "@xmldom/xmldom": "^0.8.11",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.6.2",
@@ -1440,6 +1441,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/open-location-code": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
+    "@xmldom/xmldom": "^0.8.11",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.6.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { solveDay } from './app/solveDay';
+import { emitKml } from './io/emitKml';
+import type { DayPlan } from './types';
 
 export const program = new Command();
 
@@ -24,6 +26,7 @@ program
   .option('--seed <seed>', 'Random seed', parseFloat)
   .option('--verbose', 'Print heuristic steps')
   .option('--out <file>', 'Write itinerary JSON to this path (overwrite)')
+  .option('--kml [file]', 'Write KML to this path (or stdout)')
   .action((opts) => {
     const result = solveDay({
       tripPath: opts.trip,
@@ -39,7 +42,19 @@ program
       writeFileSync(opts.out, result.json, 'utf8');
       console.log(`Wrote ${opts.out}`);
     }
-    
+
+    if (opts.kml !== undefined) {
+      const data = JSON.parse(result.json) as { days: DayPlan[] };
+      const kml = emitKml(data.days);
+      if (typeof opts.kml === 'string') {
+        mkdirSync(dirname(opts.kml), { recursive: true });
+        writeFileSync(opts.kml, kml, 'utf8');
+        console.log(`Wrote ${opts.kml}`);
+      } else {
+        console.log(kml);
+      }
+    }
+
     if (opts.verbose) {
       console.log(result.json);
     }

--- a/src/io/emitKml.ts
+++ b/src/io/emitKml.ts
@@ -1,0 +1,37 @@
+import type { DayPlan } from '../types';
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/** Serialize itinerary stops to KML. */
+export function emitKml(days: DayPlan[]): string {
+  const placemarks: string[] = [];
+  const routeCoords: string[] = [];
+  for (const day of days) {
+    for (const stop of day.stops) {
+      placemarks.push(
+        `<Placemark><name>${escapeXml(stop.name)}</name><Point><coordinates>${stop.lon},${stop.lat},0</coordinates></Point></Placemark>`,
+      );
+      routeCoords.push(`${stop.lon},${stop.lat},0`);
+    }
+  }
+  const route = `<Placemark><name>Route</name><LineString><coordinates>${routeCoords.join(' ')}</coordinates></LineString></Placemark>`;
+  const doc = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<kml xmlns="http://www.opengis.net/kml/2.2">',
+    '<Document>',
+    ...placemarks,
+    route,
+    '</Document>',
+    '</kml>',
+  ];
+  return doc.join('\n');
+}
+
+export default emitKml;

--- a/tests/emitKml.test.ts
+++ b/tests/emitKml.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { solveDay } from '../src/app/solveDay';
+import { emitKml } from '../src/io/emitKml';
+import { DOMParser } from '@xmldom/xmldom';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { DayPlan } from '../src/types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('emitKml', () => {
+  it('produces KML with placemarks for each stop', () => {
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json) as { days: DayPlan[] };
+    const kml = emitKml(data.days);
+    const doc = new DOMParser().parseFromString(kml, 'text/xml');
+    const placemarks = doc.getElementsByTagName('Placemark');
+    expect(placemarks.length).toBe(data.days[0].stops.length + 1);
+    expect(doc.getElementsByTagName('LineString').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `emitKml` helper to generate placemarks and route LineString
- support `--kml` flag in CLI to output KML string or file
- test KML generation using fixtures to ensure placemarks

## Testing
- `npm run lint`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad29a024c483288943a2d8d8fda5bb