### PR TITLE
refactor: centralize time utilities

### DIFF
--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -7,11 +7,7 @@ import {
 } from './schedule';
 import { haversineMiles } from './distance';
 import type { ID } from './types';
-
-function hhmmToMin(time: string): number {
-  const [hh, mm] = time.split(':').map(Number);
-  return hh * 60 + mm;
-}
+import { hhmmToMin } from './time';
 
 export interface HeuristicCtx extends ScheduleCtx {
   candidateIds: ID[];

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -6,6 +6,7 @@ import type {
   Coord,
   StopPlan,
 } from './types';
+import { hhmmToMin, minToHhmm } from './time';
 
 export interface ScheduleCtx {
   start: Anchor;
@@ -22,17 +23,6 @@ export interface TimelineResult {
   totalDriveMin: number;
   totalDwellMin: number;
   hotelETAmin: number;
-}
-
-function hhmmToMin(time: string): number {
-  const [hh, mm] = time.split(':').map(Number);
-  return hh * 60 + mm;
-}
-
-function minToHhmm(min: number): string {
-  const h = Math.floor(min / 60);
-  const m = Math.round(min % 60);
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }
 
 function legMetrics(

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,0 +1,10 @@
+export function hhmmToMin(time: string): number {
+  const [hh, mm] = time.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+export function minToHhmm(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = Math.round(min % 60);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}

--- a/tests/schedule.test.ts
+++ b/tests/schedule.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeTimeline, slackMin } from '../src/schedule';
 import type { ScheduleCtx } from '../src/schedule';
+import { hhmmToMin } from '../src/time';
 
 function buildCtx(): ScheduleCtx {
   return {
@@ -13,11 +14,6 @@ function buildCtx(): ScheduleCtx {
       A: { id: 'A', name: 'A', coord: [5, 0] },
     },
   };
-}
-
-function hhmmToMin(time: string): number {
-  const [hh, mm] = time.split(':').map(Number);
-  return hh * 60 + mm;
 }
 
 describe('schedule utilities', () => {

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -6,11 +6,7 @@ import { readFileSync } from 'node:fs';
 import { parseTrip } from '../src/io/parse';
 import { computeTimeline } from '../src/schedule';
 import type { Store } from '../src/types';
-
-function hhmmToMin(time: string): number {
-  const [hh, mm] = time.split(':').map(Number);
-  return hh * 60 + mm;
-}
+import { hhmmToMin } from '../src/time';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- add reusable hh:mm conversion helpers
- remove duplicate hhmm/min conversions from schedule, heuristics, and tests

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad3740e3f48328af7ad9e25066ed25