### PR TITLE
Print solution JSON by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,7 @@ program
       }
     }
 
-    if (opts.verbose) {
-      console.log(result.json);
-    }
+    console.log(result.json);
   });
   
 export function run(argv: readonly string[] = process.argv): Command {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { program } from '../src/index';
+import { describe, it, expect, vi } from 'vitest';
+import { program, run } from '../src/index';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 describe('CLI', () => {
   it('configures the commander program', () => {
@@ -12,5 +14,26 @@ describe('CLI', () => {
   it('registers verbose flag for solve-day', () => {
     const cmd = program.commands.find((c) => c.name() === 'solve-day');
     expect(cmd?.options.some((o) => o.long === '--verbose')).toBe(true);
+  });
+
+  it('prints solution JSON by default', () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    run([
+      'node',
+      'rustbelt',
+      'solve-day',
+      '--trip',
+      tripPath,
+      '--day',
+      'D1',
+    ]);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(() => JSON.parse(log.mock.calls[0][0])).not.toThrow();
+    log.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Always print solver JSON results from the CLI action
- Keep `--out` file writing and adjust CLI tests for default JSON output

## Testing
- `npm test` *(fails: expected 287433.752541 to be less than 60000)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad3c4c6200832882a9484954141a7f