### PR TITLE
Support locked stops in daily solver

### DIFF
--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -3,7 +3,7 @@ import { parseTrip } from '../io/parse';
 import { planDay } from '../heuristics';
 import { computeTimeline, slackMin, isFeasible } from '../schedule';
 import { emitItinerary, EmitResult } from '../io/emit';
-import type { ID, Store, DayPlan } from '../types';
+import type { ID, Store, DayPlan, LockSpec } from '../types';
 
 export interface SolveDayOptions {
   tripPath: string;
@@ -12,6 +12,7 @@ export interface SolveDayOptions {
   defaultDwellMin?: number;
   seed?: number;
   verbose?: boolean;
+  locks?: LockSpec[];
 }
 
 function hhmmToMin(time: string): number {
@@ -53,6 +54,7 @@ export function solveDay(opts: SolveDayOptions): EmitResult {
     defaultDwellMin,
     stores,
     mustVisitIds: day.mustVisitIds,
+    locks: opts.locks ?? day.locks,
     candidateIds,
     seed: opts.seed ?? trip.config.seed,
     verbose: opts.verbose,

--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -5,19 +5,76 @@ import {
   slackMin,
   ScheduleCtx,
 } from './schedule';
-import { haversineMiles } from './distance';
-import type { ID } from './types';
+import type { ID, LockSpec } from './types';
 import { hhmmToMin } from './time';
 
 export interface HeuristicCtx extends ScheduleCtx {
   candidateIds: ID[];
   seed?: number;
   verbose?: boolean;
+  locks?: LockSpec[];
+}
+
+interface LockPlacement {
+  order: ID[];
+  prefix: number;
+  suffix: number;
+}
+
+function applyLocks(ctx: HeuristicCtx): LockPlacement {
+  const prefix: ID[] = [];
+  const suffix: ID[] = [];
+  for (const lock of ctx.locks ?? []) {
+    const id = lock.storeId;
+    if (!ctx.stores[id]) continue;
+    if ('position' in lock) {
+      if (lock.position === 'firstAfterStart') {
+        prefix.splice(0, 0, id);
+      } else if (lock.position === 'lastBeforeEnd') {
+        suffix.push(id);
+      }
+    } else if ('index' in lock) {
+      const idx = Math.min(lock.index, prefix.length);
+      prefix.splice(idx, 0, id);
+    } else if ('afterStoreId' in lock) {
+      const idx = prefix.indexOf(lock.afterStoreId);
+      if (idx !== -1) {
+        prefix.splice(idx + 1, 0, id);
+      }
+    }
+  }
+  return { order: prefix.concat(suffix), prefix: prefix.length, suffix: suffix.length };
+}
+
+function seedMustVisits(
+  order: ID[],
+  ctx: HeuristicCtx,
+  prefix = 0,
+  suffix = 0,
+): void {
+  const ids = ctx.mustVisitIds;
+  if (!ids) return;
+  for (const id of ids) {
+    if (!ctx.stores[id] || order.includes(id)) continue;
+    let bestPos = prefix;
+    let bestEta = Infinity;
+    for (let pos = prefix; pos <= order.length - suffix; pos++) {
+      const candidate = order.slice();
+      candidate.splice(pos, 0, id);
+      const eta = computeTimeline(candidate, ctx).hotelETAmin;
+      if (eta < bestEta - 1e-9) {
+        bestEta = eta;
+        bestPos = pos;
+      }
+    }
+    order.splice(bestPos, 0, id);
+  }
 }
 
 export function planDay(ctx: HeuristicCtx): ID[] {
   const rng = seedrandom(String(ctx.seed ?? 0));
-  const order = seedMustVisits(ctx, rng);
+  const { order, prefix, suffix } = applyLocks(ctx);
+  seedMustVisits(order, ctx, prefix, suffix);
   if (!isFeasible(order, ctx)) {
     const { hotelETAmin } = computeTimeline(order, ctx);
     const endMin = hhmmToMin(ctx.window.end);
@@ -25,39 +82,9 @@ export function planDay(ctx: HeuristicCtx): ID[] {
     throw new Error(`must visits exceed day window by ${Math.round(deficit)} min`);
   }
   const remaining = ctx.candidateIds.filter((id) => !order.includes(id));
-  greedyInsert(order, remaining, ctx, rng);
-  twoOpt(order, ctx);
-  relocate(order, ctx);
-  return order;
-}
-
-function seedMustVisits(
-  ctx: HeuristicCtx,
-  rng: seedrandom.PRNG,
-): ID[] {
-  const { mustVisitIds } = ctx;
-  if (!mustVisitIds || mustVisitIds.length === 0) return [];
-  const remaining = mustVisitIds.filter((id) => ctx.stores[id]);
-  const order: ID[] = [];
-  let currentCoord = ctx.start.coord;
-  while (remaining.length > 0) {
-    let bestDist = Infinity;
-    const bestIds: ID[] = [];
-    for (const id of remaining) {
-      const dist = haversineMiles(currentCoord, ctx.stores[id].coord);
-      if (dist < bestDist - 1e-9) {
-        bestDist = dist;
-        bestIds.length = 0;
-        bestIds.push(id);
-      } else if (Math.abs(dist - bestDist) < 1e-9) {
-        bestIds.push(id);
-      }
-    }
-    const pick = bestIds[Math.floor(rng() * bestIds.length)];
-    order.push(pick);
-    currentCoord = ctx.stores[pick].coord;
-    remaining.splice(remaining.indexOf(pick), 1);
-  }
+  greedyInsert(order, remaining, ctx, rng, prefix, suffix);
+  twoOpt(order, ctx, prefix, suffix);
+  relocate(order, ctx, prefix, suffix);
   return order;
 }
 
@@ -66,6 +93,8 @@ function greedyInsert(
   remaining: ID[],
   ctx: HeuristicCtx,
   rng: seedrandom.PRNG,
+  prefix = 0,
+  suffix = 0,
 ): void {
   while (remaining.length > 0) {
     const base = computeTimeline(order, ctx);
@@ -76,7 +105,7 @@ function greedyInsert(
     let bestSlack = -Infinity;
     let bestDrive = Infinity;
     for (const id of remaining) {
-      for (let pos = 0; pos <= order.length; pos++) {
+      for (let pos = prefix; pos <= order.length - suffix; pos++) {
         const candidate = order.slice();
         candidate.splice(pos, 0, id);
         if (!isFeasible(candidate, ctx)) continue;
@@ -109,14 +138,19 @@ function greedyInsert(
   }
 }
 
-function twoOpt(order: ID[], ctx: HeuristicCtx): void {
+function twoOpt(
+  order: ID[],
+  ctx: HeuristicCtx,
+  prefix = 0,
+  suffix = 0,
+): void {
   let improved = true;
   while (improved) {
     improved = false;
     const baseSlack = slackMin(order, ctx);
     const baseDrive = computeTimeline(order, ctx).totalDriveMin;
-    outer: for (let i = 0; i < order.length - 1; i++) {
-      for (let j = i + 1; j < order.length; j++) {
+    outer: for (let i = prefix; i < order.length - suffix - 1; i++) {
+      for (let j = i + 1; j < order.length - suffix; j++) {
         const before = order.slice(i, j + 1);
         const candidate = order.slice();
         const segment = candidate.slice(i, j + 1).reverse();
@@ -140,17 +174,22 @@ function twoOpt(order: ID[], ctx: HeuristicCtx): void {
   }
 }
 
-function relocate(order: ID[], ctx: HeuristicCtx): void {
+function relocate(
+  order: ID[],
+  ctx: HeuristicCtx,
+  prefix = 0,
+  suffix = 0,
+): void {
   let improved = true;
   while (improved) {
     improved = false;
     const baseSlack = slackMin(order, ctx);
     const baseDrive = computeTimeline(order, ctx).totalDriveMin;
-    outer: for (let i = 0; i < order.length; i++) {
+    outer: for (let i = prefix; i < order.length - suffix; i++) {
       const id = order[i];
       const removed = order.slice();
       removed.splice(i, 1);
-      for (let j = 0; j <= removed.length; j++) {
+      for (let j = prefix; j <= removed.length - suffix; j++) {
         if (j === i) continue;
         const candidate = removed.slice();
         candidate.splice(j, 0, id);

--- a/tests/locks.test.ts
+++ b/tests/locks.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { planDay } from '../src/heuristics';
+import type { HeuristicCtx } from '../src/heuristics';
+
+describe('locks', () => {
+  it('respects fixed indices', () => {
+    const ctx: HeuristicCtx = {
+      start: { id: 'S', name: 'start', coord: [0, 0] },
+      end: { id: 'E', name: 'end', coord: [10, 0] },
+      window: { start: '00:00', end: '23:59' },
+      mph: 60,
+      defaultDwellMin: 0,
+      stores: {
+        A: { id: 'A', name: 'A', coord: [2, 0] },
+        B: { id: 'B', name: 'B', coord: [4, 0] },
+        C: { id: 'C', name: 'C', coord: [6, 0] },
+        D: { id: 'D', name: 'D', coord: [8, 0] },
+      },
+      candidateIds: ['A', 'B', 'C', 'D'],
+      locks: [
+        { storeId: 'A', position: 'firstAfterStart' },
+        { storeId: 'B', index: 1 },
+      ],
+    };
+    const order = planDay(ctx);
+    expect(order[0]).toBe('A');
+    expect(order[1]).toBe('B');
+  });
+
+  it('keeps relative positions', () => {
+    const ctx: HeuristicCtx = {
+      start: { id: 'S', name: 'start', coord: [0, 0] },
+      end: { id: 'E', name: 'end', coord: [10, 0] },
+      window: { start: '00:00', end: '23:59' },
+      mph: 60,
+      defaultDwellMin: 0,
+      stores: {
+        A: { id: 'A', name: 'A', coord: [1, 0] },
+        B: { id: 'B', name: 'B', coord: [2, 0] },
+        C: { id: 'C', name: 'C', coord: [3, 0] },
+        D: { id: 'D', name: 'D', coord: [4, 0] },
+      },
+      candidateIds: ['A', 'B', 'C', 'D'],
+      locks: [
+        { storeId: 'A', position: 'firstAfterStart' },
+        { storeId: 'B', afterStoreId: 'A' },
+        { storeId: 'D', position: 'lastBeforeEnd' },
+      ],
+    };
+    const order = planDay(ctx);
+    const idxA = order.indexOf('A');
+    const idxB = order.indexOf('B');
+    expect(idxA).toBe(0);
+    expect(idxB).toBe(idxA + 1);
+    expect(order[order.length - 1]).toBe('D');
+  });
+});


### PR DESCRIPTION
## Summary
- propagate `locks` from `DayConfig` into daily solver options
- honor locked stop positions during heuristic planning
- test fixed indices and relative ordering of locked stops

## Testing
- `npm test` *(fails: environment limitation on synthetic-day performance test)*

------
https://chatgpt.com/codex/tasks/task_e_68ad45351d788328974ffef642fdddf0