### PR TITLE
feat: add infeasibility advisor

### DIFF
--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -1,0 +1,2 @@
+export { solveDay as reoptimizeDay } from './solveDay';
+export type { SolveDayOptions as ReoptimizeDayOptions } from './solveDay';

--- a/src/infeasibility.ts
+++ b/src/infeasibility.ts
@@ -1,0 +1,70 @@
+import { computeTimeline, ScheduleCtx } from './schedule';
+import { hhmmToMin } from './time';
+import type { ID } from './types';
+
+export type InfeasibilitySuggestion =
+  | { type: 'extendEnd'; minutes: number }
+  | { type: 'dropMustVisit'; storeId: ID; minutesSaved: number }
+  | { type: 'dropStore'; storeId: ID; minutesSaved: number };
+
+/**
+ * Analyze infeasible schedules and suggest relaxations ranked by time saved.
+ */
+export function adviseInfeasible(
+  order: ID[],
+  ctx: ScheduleCtx,
+): InfeasibilitySuggestion[] {
+  const suggestions: InfeasibilitySuggestion[] = [];
+  const timeline = computeTimeline(order, ctx);
+  const endMin = hhmmToMin(ctx.window.end);
+  const deficit = timeline.hotelETAmin - endMin;
+  if (deficit <= 0) {
+    return suggestions;
+  }
+
+  suggestions.push({ type: 'extendEnd', minutes: Math.round(deficit) });
+
+  // Must-visit chain infeasibility
+  if (ctx.mustVisitIds && ctx.mustVisitIds.length > 0) {
+    const chainTimeline = computeTimeline(ctx.mustVisitIds, ctx);
+    if (chainTimeline.hotelETAmin > endMin) {
+      for (const id of ctx.mustVisitIds) {
+        const filtered = ctx.mustVisitIds.filter((m) => m !== id);
+        const t = computeTimeline(filtered, ctx);
+        const saved = chainTimeline.hotelETAmin - t.hotelETAmin;
+        suggestions.push({
+          type: 'dropMustVisit',
+          storeId: id,
+          minutesSaved: Math.round(saved),
+        });
+      }
+    }
+  }
+
+  // Overfull store set analysis
+  for (const id of order) {
+    if (ctx.mustVisitIds && ctx.mustVisitIds.includes(id)) {
+      continue;
+    }
+    const filtered = order.filter((s) => s !== id);
+    const t = computeTimeline(filtered, ctx);
+    if (t.hotelETAmin <= endMin) {
+      const saved = timeline.hotelETAmin - t.hotelETAmin;
+      suggestions.push({
+        type: 'dropStore',
+        storeId: id,
+        minutesSaved: Math.round(saved),
+      });
+    }
+  }
+
+  suggestions.sort((a, b) => {
+    const av = 'minutesSaved' in a ? a.minutesSaved : a.minutes;
+    const bv = 'minutesSaved' in b ? b.minutesSaved : b.minutes;
+    return bv - av;
+  });
+
+  return suggestions;
+}
+
+export default adviseInfeasible;

--- a/tests/infeasibility.test.ts
+++ b/tests/infeasibility.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { adviseInfeasible } from '../src/infeasibility';
+import type { ScheduleCtx } from '../src/schedule';
+
+describe('infeasibility advisor', () => {
+  it('suggests dropping stores for overfull sets', () => {
+    const ctx: ScheduleCtx = {
+      start: { id: 'S', name: 'S', coord: [0, 0] },
+      end: { id: 'E', name: 'E', coord: [0, 0] },
+      window: { start: '09:00', end: '10:00' },
+      mph: 60,
+      defaultDwellMin: 0,
+      stores: {
+        A: { id: 'A', name: 'A', coord: [0, 0], dwellMin: 40 },
+        B: { id: 'B', name: 'B', coord: [0, 0], dwellMin: 40 },
+      },
+    };
+    const order = ['A', 'B'];
+    const suggestions = adviseInfeasible(order, ctx);
+    const types = suggestions.map((s) => s.type);
+    expect(types).toContain('extendEnd');
+    expect(types).toContain('dropStore');
+    const drop = suggestions.find((s) => s.type === 'dropStore') as
+      | { type: 'dropStore'; storeId: string }
+      | undefined;
+    expect(drop?.storeId).toBeDefined();
+  });
+});

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -51,8 +51,20 @@ describe('solveDay', () => {
     const { hotelETAmin } = computeTimeline(day.mustVisitIds!, ctx);
     const endMin = hhmmToMin(day.window.end);
     const deficit = Math.round(hotelETAmin - endMin);
-    expect(() => solveDay({ tripPath, dayId: 'D1' })).toThrowError(
-      `must visits exceed day window by ${deficit} min`,
-    );
+    try {
+      solveDay({ tripPath, dayId: 'D1' });
+      throw new Error('expected solveDay to throw');
+    } catch (err) {
+      const e = err as Error;
+      expect(e.message).toContain(
+        `must visits exceed day window by ${deficit} min`,
+      );
+      const match = e.message.match(/suggestions: (.*)$/);
+      expect(match).not.toBeNull();
+      const suggestions = JSON.parse(match![1]);
+      const types = suggestions.map((s: { type: string }) => s.type);
+      expect(types).toContain('extendEnd');
+      expect(types).toContain('dropMustVisit');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add infeasibility advisor to propose extending day or dropping conflicting stores
- wire solveDay to include ranked suggestions when optimization fails
- cover infeasible scenarios with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adba778f248328bccab1d8eb220e70