### PR TITLE
feat: add heuristic progress logging

### DIFF
--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -1,9 +1,6 @@
-export { solveDay as reoptimizeDay } from './solveDay';
-export type { SolveDayOptions as ReoptimizeDayOptions } from './solveDay';
-
 import { readFileSync } from 'node:fs';
 import { parseTrip } from '../io/parse';
-import { planDay } from '../heuristics';
+import { planDay, type ProgressFn } from '../heuristics';
 import { computeTimeline, slackMin, isFeasible } from '../schedule';
 import { emitItinerary, EmitResult } from '../io/emit';
 import type { ID, Store, DayPlan, LockSpec, Coord } from '../types';
@@ -18,6 +15,7 @@ export interface ReoptimizeDayOptions {
   verbose?: boolean;
   locks?: LockSpec[];
   completedIds?: ID[];
+  progress?: ProgressFn;
 }
 
 export function reoptimizeDay(
@@ -80,6 +78,7 @@ export function reoptimizeDay(
     candidateIds,
     seed: opts.seed ?? trip.config.seed,
     verbose: opts.verbose,
+    progress: opts.progress,
   };
 
   const order = planDay(ctx);

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { parseTrip } from '../io/parse';
-import { planDay } from '../heuristics';
+import { planDay, type ProgressFn } from '../heuristics';
 import { computeTimeline, slackMin, isFeasible } from '../schedule';
 import { adviseInfeasible } from '../infeasibility';
 import { emitItinerary, EmitResult } from '../io/emit';
@@ -14,6 +14,7 @@ export interface SolveDayOptions {
   seed?: number;
   verbose?: boolean;
   locks?: LockSpec[];
+  progress?: ProgressFn;
 }
 
 function hhmmToMin(time: string): number {
@@ -59,6 +60,7 @@ export function solveDay(opts: SolveDayOptions): EmitResult {
     candidateIds,
     seed: opts.seed ?? trip.config.seed,
     verbose: opts.verbose,
+    progress: opts.progress,
   };
 
   let order: ID[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ program
   )
   .option('--seed <seed>', 'Random seed', parseFloat)
   .option('--verbose', 'Print heuristic steps')
+  .option('--progress', 'Print heuristic progress')
   .option('--now <HH:mm>', 'Reoptimize from this time')
   .option('--at <lat,lon>', 'Current location')
   .option('--out <file>', 'Write itinerary JSON to this path (overwrite)')
@@ -44,6 +45,14 @@ program
           defaultDwellMin: opts.defaultDwell,
           seed: opts.seed,
           verbose: opts.verbose,
+          progress: opts.progress
+            ? (phase, order, metrics) =>
+                console.log(
+                  `progress ${phase}: stops=${order.length} slack=${metrics.slackMin.toFixed(
+                    1,
+                  )} drive=${metrics.totalDriveMin.toFixed(1)}`,
+                )
+            : undefined,
         },
       );
     } else {
@@ -54,6 +63,14 @@ program
         defaultDwellMin: opts.defaultDwell,
         seed: opts.seed,
         verbose: opts.verbose,
+        progress: opts.progress
+          ? (phase, order, metrics) =>
+              console.log(
+                `progress ${phase}: stops=${order.length} slack=${metrics.slackMin.toFixed(
+                  1,
+                )} drive=${metrics.totalDriveMin.toFixed(1)}`,
+              )
+          : undefined,
       });
     }
   

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -16,6 +16,11 @@ describe('CLI', () => {
     expect(cmd?.options.some((o) => o.long === '--verbose')).toBe(true);
   });
 
+  it('registers progress flag for solve-day', () => {
+    const cmd = program.commands.find((c) => c.name() === 'solve-day');
+    expect(cmd?.options.some((o) => o.long === '--progress')).toBe(true);
+  });
+
   it('prints solution JSON by default', () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
@@ -34,6 +39,30 @@ describe('CLI', () => {
 
     expect(log).toHaveBeenCalledTimes(1);
     expect(() => JSON.parse(log.mock.calls[0][0])).not.toThrow();
+    log.mockRestore();
+  });
+
+  it('prints progress snapshots when enabled', () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    run([
+      'node',
+      'rustbelt',
+      'solve-day',
+      '--trip',
+      tripPath,
+      '--day',
+      'D1',
+      '--progress',
+    ]);
+
+    const progressCalls = log.mock.calls.filter((c) =>
+      String(c[0]).includes('progress'),
+    );
+    expect(progressCalls.length).toBeGreaterThan(0);
     log.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add progress callback and reporting in heuristics
- expose `--progress` CLI flag to print progress snapshots
- test CLI progress output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2e29808c8328a8135839e410cb79