### PR TITLE
feat: surface relax lock suggestions for infeasible days

### DIFF
--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -67,7 +67,13 @@ export function solveDay(opts: SolveDayOptions): EmitResult {
   try {
     order = planDay(ctx);
   } catch (err) {
-    const suggestions = adviseInfeasible(ctx.mustVisitIds ?? [], ctx);
+    const adviceOrder = Array.from(
+      new Set([
+        ...(ctx.mustVisitIds ?? []),
+        ...(ctx.locks?.map((l) => l.storeId) ?? []),
+      ]),
+    );
+    const suggestions = adviseInfeasible(adviceOrder, ctx);
     const newErr = new Error(
       `${(err as Error).message}; suggestions: ${JSON.stringify(suggestions)}`,
     );

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -5,6 +5,7 @@ import type {
   ID,
   Coord,
   StopPlan,
+  LockSpec,
 } from './types';
 import { hhmmToMin, minToHhmm } from './time';
 
@@ -16,6 +17,7 @@ export interface ScheduleCtx {
   defaultDwellMin: number;
   stores: Record<ID, Store>;
   mustVisitIds?: ID[];
+  locks?: LockSpec[];
 }
 
 export interface TimelineResult {


### PR DESCRIPTION
## Summary
- detect time savings from moving locked stops and offer `relaxLock` suggestions
- expose lock context to infeasibility checks and propagate suggestions in CLI flows
- test that relaxing a lock is ranked among infeasibility options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3328a1bc832891b3d38a27b1f1e3