### PR TITLE
feat: add progress callbacks during heuristic improvements

### DIFF
--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -165,6 +165,7 @@ function greedyInsert(
     if (ctx.verbose) {
       console.log(`insert ${bestId} at ${bestPos}`);
     }
+    reportProgress('greedy', order, ctx);
   }
 }
 
@@ -196,6 +197,7 @@ function twoOpt(
             const after = candidate.slice(i, j + 1);
             console.log('2-opt swap', before, '->', after);
           }
+          reportProgress('2-opt', order, ctx);
           improved = true;
           break outer;
         }
@@ -233,6 +235,7 @@ function relocate(
           if (ctx.verbose) {
             console.log(`relocate ${id} from ${i} to ${j}`);
           }
+          reportProgress('relocate', order, ctx);
           improved = true;
           break outer;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ program
                 console.log(
                   `progress ${phase}: stops=${order.length} slack=${metrics.slackMin.toFixed(
                     1,
-                  )} drive=${metrics.totalDriveMin.toFixed(1)}`,
+                  )} drive=${metrics.totalDriveMin.toFixed(1)} eta=${metrics.hotelETAmin.toFixed(1)}`,
                 )
             : undefined,
         },
@@ -76,7 +76,7 @@ program
               console.log(
                 `progress ${phase}: stops=${order.length} slack=${metrics.slackMin.toFixed(
                   1,
-                )} drive=${metrics.totalDriveMin.toFixed(1)}`,
+                )} drive=${metrics.totalDriveMin.toFixed(1)} eta=${metrics.hotelETAmin.toFixed(1)}`,
               )
           : undefined,
       });

--- a/tests/heuristics.test.ts
+++ b/tests/heuristics.test.ts
@@ -34,5 +34,22 @@ describe('heuristics', () => {
     const b = planDay(ctx2);
     expect(a).toEqual(b);
   });
+
+  it('reports progress snapshots with metrics', () => {
+    const ctx = buildCtx();
+    const phases: string[] = [];
+    const metrics: number[][] = [];
+    ctx.progress = (phase, _order, m) => {
+      phases.push(phase);
+      metrics.push([m.slackMin, m.totalDriveMin, m.hotelETAmin]);
+    };
+    planDay(ctx);
+    expect(phases).toEqual(['greedy', 'greedy', 'greedy', '2-opt', 'relocate']);
+    for (const [slack, drive, eta] of metrics) {
+      expect(typeof slack).toBe('number');
+      expect(typeof drive).toBe('number');
+      expect(typeof eta).toBe('number');
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- notify `ctx.progress` after each accepted greedy insert, 2-opt, and relocate move
- log hotel ETA in `--progress` output
- exercise progress callbacks in heuristic tests

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae68bde93083289ca5b3a739835aeb