### PR TITLE
refactor shared day-solving helper

### DIFF
--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { parseTrip } from '../io/parse';
-import { planDay, type ProgressFn } from '../heuristics';
-import { computeTimeline, slackMin, isFeasible } from '../schedule';
-import { adviseInfeasible } from '../infeasibility';
 import { emitItinerary, EmitResult } from '../io/emit';
-import type { ID, Store, DayPlan, LockSpec, Coord } from '../types';
-import { hhmmToMin } from '../time';
+import { solveCommon } from './solveCommon';
+import type { ID, LockSpec, Coord } from '../types';
+import type { ProgressFn } from '../heuristics';
 
 export interface ReoptimizeDayOptions {
   tripPath: string;
@@ -24,106 +20,20 @@ export function reoptimizeDay(
   atCoord: Coord,
   opts: ReoptimizeDayOptions,
 ): EmitResult {
-  const raw = readFileSync(opts.tripPath, 'utf8');
-  const json = JSON.parse(raw);
-  const trip = parseTrip(json);
-
-  const day = trip.days.find((d) => d.dayId === opts.dayId);
-  if (!day) {
-    throw new Error(`Day not found: ${opts.dayId}`);
-  }
-
-  const mph = opts.mph ?? day.mph ?? trip.config.mph ?? 30;
-  const defaultDwellMin =
-    opts.defaultDwellMin ??
-    day.defaultDwellMin ??
-    trip.config.defaultDwellMin ??
-    0;
-
-  const stores: Record<ID, Store> = {};
-  let candidateIds: ID[] = [];
-  for (const s of trip.stores) {
-    if (!s.dayId || s.dayId === day.dayId) {
-      stores[s.id] = s;
-      candidateIds.push(s.id);
-    }
-  }
-
-  // remove completed stops
-  if (opts.completedIds) {
-    const done = new Set(opts.completedIds);
-    candidateIds = candidateIds.filter((id) => !done.has(id));
-  }
-
-  let mustVisitIds = day.mustVisitIds?.filter((id) => candidateIds.includes(id));
-  let locks = (opts.locks ?? day.locks)?.filter((l) => candidateIds.includes(l.storeId));
-
-  const baseCtx = {
-    start: { ...day.start, coord: atCoord },
-    end: day.end,
-    window: { start: now, end: day.window.end },
-    mph,
-    defaultDwellMin,
-    stores,
-  };
-
-  // drop individually infeasible stops
-  candidateIds = candidateIds.filter((id) => isFeasible([id], baseCtx));
-  mustVisitIds = mustVisitIds?.filter((id) => candidateIds.includes(id));
-  locks = locks?.filter((l) => candidateIds.includes(l.storeId));
-
-  const ctx = {
-    ...baseCtx,
-    mustVisitIds,
-    locks,
-    candidateIds,
-    seed: opts.seed ?? trip.config.seed,
+  const dayPlan = solveCommon({
+    tripPath: opts.tripPath,
+    dayId: opts.dayId,
+    startCoord: atCoord,
+    windowStart: now,
+    completedIds: opts.completedIds,
+    mph: opts.mph,
+    defaultDwellMin: opts.defaultDwellMin,
+    seed: opts.seed,
     verbose: opts.verbose,
+    locks: opts.locks,
     progress: opts.progress,
-  };
-
-  let order: ID[];
-  try {
-    order = planDay(ctx);
-  } catch (err) {
-    const adviceOrder = Array.from(
-      new Set([
-        ...(ctx.mustVisitIds ?? []),
-        ...(ctx.locks?.map((l) => l.storeId) ?? []),
-      ]),
-    );
-    const suggestions = adviseInfeasible(adviceOrder, ctx);
-    const newErr = new Error(
-      `${(err as Error).message}; suggestions: ${JSON.stringify(suggestions)}`,
-    );
-    (newErr as Error & { suggestions?: unknown[] }).suggestions = suggestions;
-    throw newErr;
-  }
-  const feasible = isFeasible(order, ctx);
-  const timeline = computeTimeline(order, ctx);
-  if (!feasible) {
-    const suggestions = adviseInfeasible(order, ctx);
-    const endMin = hhmmToMin(ctx.window.end);
-    const deficit = timeline.hotelETAmin - endMin;
-    const err = new Error(
-      `must visits exceed day window by ${Math.round(deficit)} min; suggestions: ${JSON.stringify(
-        suggestions,
-      )}`,
-    );
-    (err as Error & { suggestions?: unknown[] }).suggestions = suggestions;
-    throw err;
-  }
-
-  const dayPlan: DayPlan = {
-    dayId: day.dayId,
-    stops: timeline.stops,
-    metrics: {
-      storesVisited: order.length,
-      totalDriveMin: timeline.totalDriveMin,
-      totalDwellMin: timeline.totalDwellMin,
-      slackMin: slackMin(order, ctx),
-    },
-  };
+  });
 
   return emitItinerary([dayPlan]);
 }
+

--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { parseTrip } from '../io/parse';
+import { planDay, type ProgressFn } from '../heuristics';
+import { computeTimeline, slackMin, isFeasible, type ScheduleCtx } from '../schedule';
+import { adviseInfeasible } from '../infeasibility';
+import { hhmmToMin } from '../time';
+import type { ID, Store, DayPlan, LockSpec, Coord } from '../types';
+
+export interface SolveCommonOptions {
+  tripPath: string;
+  dayId: string;
+  startCoord?: Coord;
+  windowStart?: string;
+  mph?: number;
+  defaultDwellMin?: number;
+  seed?: number;
+  verbose?: boolean;
+  locks?: LockSpec[];
+  completedIds?: ID[];
+  progress?: ProgressFn;
+}
+
+export function solveCommon(opts: SolveCommonOptions): DayPlan {
+  const raw = readFileSync(opts.tripPath, 'utf8');
+  const json = JSON.parse(raw);
+  const trip = parseTrip(json);
+
+  const day = trip.days.find((d) => d.dayId === opts.dayId);
+  if (!day) {
+    throw new Error(`Day not found: ${opts.dayId}`);
+  }
+
+  const mph = opts.mph ?? day.mph ?? trip.config.mph ?? 30;
+  const defaultDwellMin =
+    opts.defaultDwellMin ??
+    day.defaultDwellMin ??
+    trip.config.defaultDwellMin ??
+    0;
+
+  const stores: Record<ID, Store> = {};
+  let candidateIds: ID[] = [];
+  for (const s of trip.stores) {
+    if (!s.dayId || s.dayId === day.dayId) {
+      stores[s.id] = s;
+      candidateIds.push(s.id);
+    }
+  }
+
+  if (opts.completedIds) {
+    const done = new Set(opts.completedIds);
+    candidateIds = candidateIds.filter((id) => !done.has(id));
+  }
+
+  let mustVisitIds = day.mustVisitIds?.filter((id) => candidateIds.includes(id));
+  let locks = (opts.locks ?? day.locks)?.filter((l) => candidateIds.includes(l.storeId));
+
+  const start = { ...day.start, coord: opts.startCoord ?? day.start.coord };
+  const window = { start: opts.windowStart ?? day.window.start, end: day.window.end };
+
+  const baseCtx: ScheduleCtx = {
+    start,
+    end: day.end,
+    window,
+    mph,
+    defaultDwellMin,
+    stores,
+  };
+
+  if (opts.completedIds || opts.startCoord || opts.windowStart) {
+    candidateIds = candidateIds.filter((id) => isFeasible([id], baseCtx));
+    mustVisitIds = mustVisitIds?.filter((id) => candidateIds.includes(id));
+    locks = locks?.filter((l) => candidateIds.includes(l.storeId));
+  }
+
+  const ctx = {
+    ...baseCtx,
+    mustVisitIds,
+    locks,
+    candidateIds,
+    seed: opts.seed ?? trip.config.seed,
+    verbose: opts.verbose,
+    progress: opts.progress,
+  };
+
+  let order: ID[];
+  try {
+    order = planDay(ctx);
+  } catch (err) {
+    const adviceOrder = Array.from(
+      new Set([
+        ...(ctx.mustVisitIds ?? []),
+        ...(ctx.locks?.map((l) => l.storeId) ?? []),
+      ]),
+    );
+    const suggestions = adviseInfeasible(adviceOrder, ctx);
+    const newErr = new Error(
+      `${(err as Error).message}; suggestions: ${JSON.stringify(suggestions)}`,
+    );
+    (newErr as Error & { suggestions?: unknown[] }).suggestions = suggestions;
+    throw newErr;
+  }
+  const feasible = isFeasible(order, ctx);
+  const timeline = computeTimeline(order, ctx);
+  if (!feasible) {
+    const suggestions = adviseInfeasible(order, ctx);
+    const endMin = hhmmToMin(ctx.window.end);
+    const deficit = timeline.hotelETAmin - endMin;
+    const err = new Error(
+      `must visits exceed day window by ${Math.round(deficit)} min; suggestions: ${JSON.stringify(
+        suggestions,
+      )}`,
+    );
+    (err as Error & { suggestions?: unknown[] }).suggestions = suggestions;
+    throw err;
+  }
+
+  const dayPlan: DayPlan = {
+    dayId: day.dayId,
+    stops: timeline.stops,
+    metrics: {
+      storesVisited: order.length,
+      totalDriveMin: timeline.totalDriveMin,
+      totalDwellMin: timeline.totalDwellMin,
+      slackMin: slackMin(order, ctx),
+    },
+  };
+
+  return dayPlan;
+}
+

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -1,10 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { parseTrip } from '../io/parse';
-import { planDay, type ProgressFn } from '../heuristics';
-import { computeTimeline, slackMin, isFeasible } from '../schedule';
-import { adviseInfeasible } from '../infeasibility';
 import { emitItinerary, EmitResult } from '../io/emit';
-import type { ID, Store, DayPlan, LockSpec } from '../types';
+import { solveCommon } from './solveCommon';
+import type { LockSpec } from '../types';
+import type { ProgressFn } from '../heuristics';
 
 export interface SolveDayOptions {
   tripPath: string;
@@ -17,95 +14,18 @@ export interface SolveDayOptions {
   progress?: ProgressFn;
 }
 
-function hhmmToMin(time: string): number {
-  const [hh, mm] = time.split(':').map(Number);
-  return hh * 60 + mm;
-}
-
 export function solveDay(opts: SolveDayOptions): EmitResult {
-  const raw = readFileSync(opts.tripPath, 'utf8');
-  const json = JSON.parse(raw);
-  const trip = parseTrip(json);
-
-  const day = trip.days.find((d) => d.dayId === opts.dayId);
-  if (!day) {
-    throw new Error(`Day not found: ${opts.dayId}`);
-  }
-
-  const mph = opts.mph ?? day.mph ?? trip.config.mph ?? 30;
-  const defaultDwellMin =
-    opts.defaultDwellMin ??
-    day.defaultDwellMin ??
-    trip.config.defaultDwellMin ??
-    0;
-
-  const stores: Record<ID, Store> = {};
-  const candidateIds: ID[] = [];
-  for (const s of trip.stores) {
-    if (!s.dayId || s.dayId === day.dayId) {
-      stores[s.id] = s;
-      candidateIds.push(s.id);
-    }
-  }
-
-  const ctx = {
-    start: day.start,
-    end: day.end,
-    window: day.window,
-    mph,
-    defaultDwellMin,
-    stores,
-    mustVisitIds: day.mustVisitIds,
-    locks: opts.locks ?? day.locks,
-    candidateIds,
-    seed: opts.seed ?? trip.config.seed,
+  const dayPlan = solveCommon({
+    tripPath: opts.tripPath,
+    dayId: opts.dayId,
+    mph: opts.mph,
+    defaultDwellMin: opts.defaultDwellMin,
+    seed: opts.seed,
     verbose: opts.verbose,
+    locks: opts.locks,
     progress: opts.progress,
-  };
-
-  let order: ID[];
-  try {
-    order = planDay(ctx);
-  } catch (err) {
-    const adviceOrder = Array.from(
-      new Set([
-        ...(ctx.mustVisitIds ?? []),
-        ...(ctx.locks?.map((l) => l.storeId) ?? []),
-      ]),
-    );
-    const suggestions = adviseInfeasible(adviceOrder, ctx);
-    const newErr = new Error(
-      `${(err as Error).message}; suggestions: ${JSON.stringify(suggestions)}`,
-    );
-    (newErr as Error & { suggestions?: unknown[] }).suggestions = suggestions;
-    throw newErr;
-  }
-  const feasible = isFeasible(order, ctx);
-  const timeline = computeTimeline(order, ctx);
-  if (!feasible) {
-    const suggestions = adviseInfeasible(order, ctx);
-    const endMin = hhmmToMin(ctx.window.end);
-    const deficit = timeline.hotelETAmin - endMin;
-    const err = new Error(
-      `must visits exceed day window by ${Math.round(deficit)} min; suggestions: ${JSON.stringify(
-        suggestions,
-      )}`,
-    );
-    // Attach structured suggestions for programmatic access
-    (err as Error & { suggestions?: unknown[] }).suggestions = suggestions;
-    throw err;
-  }
-
-  const dayPlan: DayPlan = {
-    dayId: day.dayId,
-    stops: timeline.stops,
-    metrics: {
-      storesVisited: order.length,
-      totalDriveMin: timeline.totalDriveMin,
-      totalDwellMin: timeline.totalDwellMin,
-      slackMin: slackMin(order, ctx),
-    },
-  };
+  });
 
   return emitItinerary([dayPlan]);
 }
+


### PR DESCRIPTION
## Summary
- factor shared trip loading and scheduling logic into `solveCommon`
- simplify `solveDay` and `reoptimizeDay` to use shared helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a4b70108328b71c274d2e54492c