### PR TITLE
feat: precompute distance matrix for scheduling

### DIFF
--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -4,6 +4,7 @@ import {
   isFeasible,
   slackMin,
   ScheduleCtx,
+  buildDistanceMatrix,
 } from './schedule';
 import type { ID, LockSpec } from './types';
 import { hhmmToMin } from './time';
@@ -85,6 +86,9 @@ function seedMustVisits(
 }
 
 export function planDay(ctx: HeuristicCtx): ID[] {
+  if (!ctx.distanceMatrix) {
+    ctx.distanceMatrix = buildDistanceMatrix(ctx);
+  }
   const rng = seedrandom(String(ctx.seed ?? 0));
   const { order, prefix, suffix } = applyLocks(ctx);
   seedMustVisits(order, ctx, prefix, suffix);


### PR DESCRIPTION
## Summary
- precompute pairwise store distances via `buildDistanceMatrix`
- have `computeTimeline` reuse cached distances
- heuristics populate the distance matrix once per planning run

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d2e5a9c8328a298616e01b886ae