### PR TITLE
Add reason strings to infeasibility suggestions

### DIFF
--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -93,8 +93,13 @@ export function solveCommon(opts: SolveCommonOptions): DayPlan {
       ]),
     );
     const suggestions = adviseInfeasible(adviceOrder, ctx);
+    const reasons = Array.from(new Set(suggestions.map((s) => s.reason))).join(
+      '; ',
+    );
     const newErr = new Error(
-      `${(err as Error).message}; suggestions: ${JSON.stringify(suggestions)}`,
+      `${(err as Error).message}; reasons: ${reasons}; suggestions: ${JSON.stringify(
+        suggestions,
+      )}`,
     );
     (newErr as Error & { suggestions?: unknown[] }).suggestions = suggestions;
     throw newErr;
@@ -105,10 +110,13 @@ export function solveCommon(opts: SolveCommonOptions): DayPlan {
     const suggestions = adviseInfeasible(order, ctx);
     const endMin = hhmmToMin(ctx.window.end);
     const deficit = timeline.hotelETAmin - endMin;
+    const reasons = Array.from(new Set(suggestions.map((s) => s.reason))).join(
+      '; ',
+    );
     const err = new Error(
-      `must visits exceed day window by ${Math.round(deficit)} min; suggestions: ${JSON.stringify(
-        suggestions,
-      )}`,
+      `must visits exceed day window by ${Math.round(
+        deficit,
+      )} min; reasons: ${reasons}; suggestions: ${JSON.stringify(suggestions)}`,
     );
     (err as Error & { suggestions?: unknown[] }).suggestions = suggestions;
     throw err;

--- a/src/infeasibility.ts
+++ b/src/infeasibility.ts
@@ -3,10 +3,10 @@ import { hhmmToMin } from './time';
 import type { ID } from './types';
 
 export type InfeasibilitySuggestion =
-  | { type: 'extendEnd'; minutes: number }
-  | { type: 'dropMustVisit'; storeId: ID; minutesSaved: number }
-  | { type: 'dropStore'; storeId: ID; minutesSaved: number }
-  | { type: 'relaxLock'; storeId: ID; minutesSaved: number };
+  | { type: 'extendEnd'; minutes: number; reason: string }
+  | { type: 'dropMustVisit'; storeId: ID; minutesSaved: number; reason: string }
+  | { type: 'dropStore'; storeId: ID; minutesSaved: number; reason: string }
+  | { type: 'relaxLock'; storeId: ID; minutesSaved: number; reason: string };
 
 /**
  * Analyze infeasible schedules and suggest relaxations ranked by time saved.
@@ -23,7 +23,11 @@ export function adviseInfeasible(
     return suggestions;
   }
 
-  suggestions.push({ type: 'extendEnd', minutes: Math.round(deficit) });
+  suggestions.push({
+    type: 'extendEnd',
+    minutes: Math.round(deficit),
+    reason: 'Schedule exceeds window',
+  });
 
   // Must-visit chain infeasibility
   if (ctx.mustVisitIds && ctx.mustVisitIds.length > 0) {
@@ -37,6 +41,7 @@ export function adviseInfeasible(
           type: 'dropMustVisit',
           storeId: id,
           minutesSaved: Math.round(saved),
+          reason: 'Must-visit chain exceeds window',
         });
       }
     }
@@ -55,6 +60,7 @@ export function adviseInfeasible(
         type: 'dropStore',
         storeId: id,
         minutesSaved: Math.round(saved),
+        reason: 'Store set exceeds window',
       });
     }
   }
@@ -81,6 +87,7 @@ export function adviseInfeasible(
           type: 'relaxLock',
           storeId: id,
           minutesSaved: Math.round(saved),
+          reason: 'Lock constraints exceed window',
         });
       }
     }

--- a/tests/infeasibility.test.ts
+++ b/tests/infeasibility.test.ts
@@ -21,9 +21,14 @@ describe('infeasibility advisor', () => {
     expect(types).toContain('extendEnd');
     expect(types).toContain('dropStore');
     const drop = suggestions.find((s) => s.type === 'dropStore') as
-      | { type: 'dropStore'; storeId: string }
+      | { type: 'dropStore'; storeId: string; reason: string }
       | undefined;
     expect(drop?.storeId).toBeDefined();
+    expect(drop?.reason).toBe('Store set exceeds window');
+    const extend = suggestions.find((s) => s.type === 'extendEnd') as
+      | { type: 'extendEnd'; reason: string }
+      | undefined;
+    expect(extend?.reason).toBe('Schedule exceeds window');
   });
 
   it('suggests relaxing locked stops', () => {
@@ -46,8 +51,14 @@ describe('infeasibility advisor', () => {
     expect(types).toContain('relaxLock');
     const relax = suggestions.find(
       (s) => s.type === 'relaxLock' && s.storeId === 'B',
-    ) as { type: 'relaxLock'; storeId: string; minutesSaved: number } | undefined;
+    ) as {
+      type: 'relaxLock';
+      storeId: string;
+      minutesSaved: number;
+      reason: string;
+    } | undefined;
     expect(relax).toBeDefined();
     expect(relax!.minutesSaved).toBeGreaterThan(0);
+    expect(relax!.reason).toBe('Lock constraints exceed window');
   });
 });

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -59,12 +59,18 @@ describe('solveDay', () => {
       expect(e.message).toContain(
         `must visits exceed day window by ${deficit} min`,
       );
+      expect(e.message).toContain('Must-visit chain exceeds window');
       const match = e.message.match(/suggestions: (.*)$/);
       expect(match).not.toBeNull();
       const suggestions = JSON.parse(match![1]);
       const types = suggestions.map((s: { type: string }) => s.type);
       expect(types).toContain('extendEnd');
       expect(types).toContain('dropMustVisit');
+      expect(
+        suggestions.every(
+          (s: { reason?: string }) => typeof s.reason === 'string',
+        ),
+      ).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary
- extend infeasibility suggestions with `reason` descriptions
- include reasons in solve errors for `solveDay` and `reoptimizeDay`
- test updates for new reason handling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68af16e823e48328b8c466f2b147f6ee