### PR TITLE
refactor: centralize error suggestion handling

### DIFF
--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -1,8 +1,7 @@
 import { emitItinerary, EmitResult } from '../io/emit';
-import { solveCommon } from './solveCommon';
+import { solveCommon, augmentErrorWithReasons } from './solveCommon';
 import type { ID, LockSpec, Coord } from '../types';
 import type { ProgressFn } from '../heuristics';
-import type { InfeasibilitySuggestion } from '../infeasibility';
 
 export interface ReoptimizeDayOptions {
   tripPath: string;
@@ -38,19 +37,7 @@ export function reoptimizeDay(
 
     return emitItinerary([dayPlan]);
   } catch (err) {
-    const e = err as Error & {
-      suggestions?: InfeasibilitySuggestion[];
-    };
-    if (e.suggestions && !e.message.includes('reasons:')) {
-      const reasons = Array.from(
-        new Set(e.suggestions.map((s) => s.reason)),
-      ).join('; ');
-      const newErr = new Error(`${e.message}; reasons: ${reasons}`);
-      (newErr as Error & { suggestions?: unknown[] }).suggestions =
-        e.suggestions;
-      throw newErr;
-    }
-    throw e;
+    throw augmentErrorWithReasons(err);
   }
 }
 

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -1,8 +1,7 @@
 import { emitItinerary, EmitResult } from '../io/emit';
-import { solveCommon } from './solveCommon';
+import { solveCommon, augmentErrorWithReasons } from './solveCommon';
 import type { LockSpec } from '../types';
 import type { ProgressFn } from '../heuristics';
-import type { InfeasibilitySuggestion } from '../infeasibility';
 
 export interface SolveDayOptions {
   tripPath: string;
@@ -30,19 +29,7 @@ export function solveDay(opts: SolveDayOptions): EmitResult {
 
     return emitItinerary([dayPlan]);
   } catch (err) {
-    const e = err as Error & {
-      suggestions?: InfeasibilitySuggestion[];
-    };
-    if (e.suggestions && !e.message.includes('reasons:')) {
-      const reasons = Array.from(
-        new Set(e.suggestions.map((s) => s.reason)),
-      ).join('; ');
-      const newErr = new Error(`${e.message}; reasons: ${reasons}`);
-      (newErr as Error & { suggestions?: unknown[] }).suggestions =
-        e.suggestions;
-      throw newErr;
-    }
-    throw e;
+    throw augmentErrorWithReasons(err);
   }
 }
 


### PR DESCRIPTION
## Summary
- centralize error message augmentation with `augmentErrorWithReasons`
- reuse helper in `solveDay` and `reoptimizeDay`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8dce2f6c8328b2ee04a28edeb4fd