### PR TITLE
refactor: consolidate coordinate tuple type

### DIFF
--- a/src/distance.ts
+++ b/src/distance.ts
@@ -1,4 +1,4 @@
-export type Coord = readonly [number, number];
+import type { Coord } from './types';
 
 /**
  * Compute pairwise Euclidean distances between a list of IDs.
@@ -39,10 +39,8 @@ export function minutesAtMph(distance: number, mph: number): number {
   return (distance / mph) * 60;
 }
 
-export type Coordinate = readonly [number, number];
-
 // Haversine formula to compute great-circle distance between two points on Earth in miles
-export function haversineMiles(a: Coordinate, b: Coordinate): number {
+export function haversineMiles(a: Coord, b: Coord): number {
   const toRad = (deg: number) => (deg * Math.PI) / 180;
   const [lat1, lon1] = a.map(toRad) as [number, number];
   const [lat2, lon2] = b.map(toRad) as [number, number];
@@ -59,7 +57,7 @@ export function haversineMiles(a: Coordinate, b: Coordinate): number {
  * Build a symmetric distance matrix in miles for the provided coordinates.
  * Only the upper triangle (j > i) is computed and mirrored to the lower triangle.
  */
-export function buildMatrix(coords: Coordinate[]): number[][] {
+export function buildMatrix(coords: Coord[]): number[][] {
   const n = coords.length;
   const matrix: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
 

--- a/tests/distance.test.ts
+++ b/tests/distance.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  pairwiseDistances,
-  minutesAtMph,
-  buildMatrix,
-  Coordinate,
-} from '../src/distance';
+import { pairwiseDistances, minutesAtMph, buildMatrix } from '../src/distance';
+import type { Coord } from '../src/types';
 
 describe('pairwiseDistances', () => {
   it('computes distances when all coordinates are present', () => {
@@ -43,7 +39,7 @@ describe('minutesAtMph', () => {
 });
 
 describe('buildMatrix', () => {
-  const coords: Coordinate[] = [
+  const coords: Coord[] = [
     [37.7749, -122.4194], // San Francisco
     [34.0522, -118.2437], // Los Angeles
     [40.7128, -74.006], // New York


### PR DESCRIPTION
## Summary
- use `Coord` as the single `[number, number]` alias
- remove obsolete `Coordinate` type and update distance utilities
- align distance tests with new `Coord` alias

## Testing
- `npm test -- --run --reporter=basic`
- `npm run lint`
- `npm run build` *(fails: missing type declarations and test typings)*

------
https://chatgpt.com/codex/tasks/task_e_68b065f204cc832892ea86a51249dc00