### PR TITLE
Clarify day handling and add trip JSON schema

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -8,14 +8,14 @@ This document describes how to use the `rustbelt` command-line interface.
 rustbelt solve-day --trip <file> --day <id> [options]
 ```
 
-`solve-day` is the default command, so it can be omitted. The tool reads a trip JSON file and produces an itinerary for the specified day. When `--now` and `--at` are provided, the solver reoptimizes the remaining day from the given time and location.
+`solve-day` is the default command, so it can be omitted. The tool reads a trip JSON file and produces an itinerary for the specified day. The trip file must contain a `days` array with `dayId` values; `--day` selects which entry to solve. The flag is required—omitting it or providing a non‑existent `dayId` causes the CLI to exit with an error. When `--now` and `--at` are provided, the solver reoptimizes the remaining day from the given time and location.
 
 ## Options
 
 | Flag | Description |
 | --- | --- |
 | `--trip <file>` | Path to trip JSON file |
-| `--day <id>` | Day id to solve |
+| `--day <id>` | Day id to solve (required) |
 | `--mph <mph>` | Average speed in mph |
 | `--default-dwell <min>` | Default dwell minutes |
 | `--seed <seed>` | Random seed |

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -430,6 +430,8 @@ This section specifies the data model and practical input pathways for v0.1, plu
 
 ## 5.1 Minimal Inputs for v0.1 (MVP)
 
+The full JSON structure is described in `docs/trip-schema.json`.
+
 **Trip-level config**
 
 - `mph` *(default 38\)*: constant speed used with Haversine to estimate travel time.  
@@ -454,8 +456,9 @@ This section specifies the data model and practical input pathways for v0.1, plu
 - `name` *(string)*  
 - **Location** (see **5.3**): either `{lat,lon}` or one of the supported string forms that can be normalized to lat/lon.  
 - `dwellMin` *(optional)*: default to `defaultDwellMin` if absent.  
-- `score` *(reserved for v0.3; optional)*  
+- `score` *(reserved for v0.3; optional)*
 - `tags` *(optional)*
+- `dayId` *(optional)*: restricts the store to a specific day; stores without `dayId` are considered on every day.
 
 ## 5.2 Optional Inputs by Version
 
@@ -640,9 +643,13 @@ You can defer spatial filtering without impacting v0.1/v0.2. When enabled:
 
 **CLI (v0.1 / v0.2)**
 
+Pass `--day <id>` to choose which entry in the trip's `days` array to solve.
+
 node dist/index.js \\
 
   \--trip path/to/trip.json \\
+
+  \--day 2025-10-01 \\
 
   \--mph 38 \\
 

--- a/docs/rust-belt-test-plan.md
+++ b/docs/rust-belt-test-plan.md
@@ -14,12 +14,13 @@ The steps below exercise the CLI, verify itinerary outputs, and ensure no store 
 
 1. Build a trip JSON (`trips/rust-belt.json`) with:
    - Three `dayId` entries with start/end anchors and time windows matching the legs above.
-   - A `stores` array containing all 132 stores with unique `id` values and assigned `dayId`s. Stores should appear **only once** in the file.
+   - A `stores` array containing all 132 stores with unique `id` values. Optionally assign a `dayId` to restrict a store to a single day; stores without a `dayId` are candidates on every day. Stores should appear **only once** in the file.
 2. Optional: group stores roughly by geography to balance the daily workload (e.g., Detroit downtown vs. suburbs).
-3. Validate the JSON with `jq` or a schema check before solving.
+3. Validate the JSON with `jq` or the provided schema (`docs/trip-schema.json`) before solving.
 
 ```bash
 jq . trips/rust-belt.json >/dev/null
+# ajv validate -s docs/trip-schema.json -d trips/rust-belt.json
 ```
 
 ---
@@ -106,7 +107,7 @@ Verify that:
 ## 4. Avoiding Duplicate Visits
 
 1. **Unique IDs** – ensure every store has a unique `id` in the trip file. The parser rejects duplicates.
-2. **Day assignment** – assign each store to a single `dayId`. If a store can appear on multiple days, run a post‑solve check that aggregates `storeId`s from `plans/day*.json` and flags duplicates:
+2. **Day assignment** – If you use `dayId`s, assign each store to at most one day. For stores without a `dayId`, run a post‑solve check that aggregates `storeId`s from `plans/day*.json` and flags duplicates:
 
 ```bash
 jq -r '.itinerary[].id' plans/day{1,2,3}.json | sort | uniq -d

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/trip.schema.json",
+  "title": "Rust Belt Trip",
+  "type": "object",
+  "required": ["config", "days", "stores"],
+  "properties": {
+    "config": { "$ref": "#/definitions/TripConfig" },
+    "days": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/DayConfig" }
+    },
+    "stores": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Store" }
+    }
+  },
+  "definitions": {
+    "Coord": {
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "Anchor": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "lat": { "type": "number" },
+        "lon": { "type": "number" },
+        "location": { "type": "string" }
+      },
+      "oneOf": [
+        { "required": ["lat", "lon"] },
+        { "required": ["location"] }
+      ]
+    },
+    "Store": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "lat": { "type": "number" },
+        "lon": { "type": "number" },
+        "location": { "type": "string" },
+        "dwellMin": { "type": "number" },
+        "score": { "type": "number" },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "dayId": { "type": "string" }
+      },
+      "oneOf": [
+        { "required": ["lat", "lon"] },
+        { "required": ["location"] }
+      ]
+    },
+    "LockSpec": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["storeId", "position"],
+          "properties": {
+            "storeId": { "type": "string" },
+            "position": { "enum": ["firstAfterStart", "lastBeforeEnd"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["storeId", "index"],
+          "properties": {
+            "storeId": { "type": "string" },
+            "index": { "type": "integer", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["storeId", "afterStoreId"],
+          "properties": {
+            "storeId": { "type": "string" },
+            "afterStoreId": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "DayConfig": {
+      "type": "object",
+      "required": ["dayId", "start", "end", "window"],
+      "properties": {
+        "dayId": { "type": "string" },
+        "start": { "$ref": "#/definitions/Anchor" },
+        "end": { "$ref": "#/definitions/Anchor" },
+        "window": {
+          "type": "object",
+          "required": ["start", "end"],
+          "properties": {
+            "start": { "type": "string" },
+            "end": { "type": "string" }
+          }
+        },
+        "mph": { "type": "number" },
+        "defaultDwellMin": { "type": "number" },
+        "mustVisitIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "locks": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/LockSpec" }
+        },
+        "maxDriveTime": { "type": "number" },
+        "maxStops": { "type": "number" },
+        "breakWindow": {
+          "type": "object",
+          "required": ["start", "end"],
+          "properties": {
+            "start": { "type": "string" },
+            "end": { "type": "string" }
+          }
+        },
+        "robustnessFactor": { "type": "number" },
+        "riskThresholdMin": { "type": "number" }
+      }
+    },
+    "TripConfig": {
+      "type": "object",
+      "properties": {
+        "mph": { "type": "number" },
+        "defaultDwellMin": { "type": "number" },
+        "seed": { "type": "number" },
+        "snapDuplicateToleranceMeters": { "type": "number" },
+        "robustnessFactor": { "type": "number" },
+        "riskThresholdMin": { "type": "number" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Document optional `dayId` in test plan and route planner docs
- Explain required `--day` flag and days array in CLI documentation
- Add machine-readable `trip-schema.json`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1009e43c883289cb8667cf006602e