### PR TITLE
Validate start-end drive time against day window

### DIFF
--- a/fixtures/drive-equals-window.json
+++ b/fixtures/drive-equals-window.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "mph": 69.09409442795152,
+    "defaultDwellMin": 0
+  },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "E", "name": "end", "lat": 0, "lon": 1 },
+      "window": { "start": "00:00", "end": "01:00" }
+    }
+  ],
+  "stores": []
+}

--- a/fixtures/drive-within-window.json
+++ b/fixtures/drive-within-window.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "mph": 69.09409442795152,
+    "defaultDwellMin": 0
+  },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "E", "name": "end", "lat": 0, "lon": 1 },
+      "window": { "start": "00:00", "end": "02:00" }
+    }
+  ],
+  "stores": []
+}

--- a/src/heuristics.ts
+++ b/src/heuristics.ts
@@ -108,6 +108,15 @@ export function planDay(ctx: HeuristicCtx): ID[] {
   if (!ctx.distanceMatrix) {
     ctx.distanceMatrix = buildDistanceMatrix(ctx);
   }
+  const startMin = hhmmToMin(ctx.window.start);
+  const endMin = hhmmToMin(ctx.window.end);
+  const windowMin = endMin - startMin;
+  const driveMin = computeTimeline([], ctx).totalDriveMin;
+  if (driveMin >= windowMin) {
+    throw new Error(
+      `start to end drive time ${Math.round(driveMin)} min >= window ${windowMin} min`,
+    );
+  }
   const rng = seedrandom(String(ctx.seed ?? 0));
   const { order, prefix, suffix } = applyLocks(ctx);
   seedMustVisits(order, ctx, prefix, suffix);

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -92,4 +92,19 @@ describe('solveDay', () => {
       ).toBe(true);
     }
   });
+
+  it('throws when start→end drive equals window', () => {
+    const tripPath = join(__dirname, '../fixtures/drive-equals-window.json');
+    expect(() => solveDay({ tripPath, dayId: 'D1' })).toThrow(
+      'start to end drive time 60 min >= window 60 min',
+    );
+  });
+
+  it('plans when start→end drive is shorter than window', () => {
+    const tripPath = join(__dirname, '../fixtures/drive-within-window.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    const ids = data.days[0].stops.map((s: { id: string }) => s.id);
+    expect(ids).toEqual(['S', 'E']);
+  });
 });


### PR DESCRIPTION
## Summary
- guard planDay by comparing start-to-end drive time with the available window
- add regression tests for equal and shorter start-end drive windows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a813def08328bc6dfee743d8d606