### PR TITLE
Use Mustache templates for HTML itinerary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# rustbelt
+
+Utility for planning store visits.
+
+## HTML Templates
+
+HTML itineraries are rendered with [Mustache](https://mustache.github.io/) templates.
+The default template is `src/io/templates/itinerary.mustache` which includes
+a `stop` partial for each stop row.
+
+You can customize the HTML output by providing your own template or partials
+to `emitHtml`:
+
+```ts
+import { readFileSync } from 'fs';
+import { emitHtml } from './src/io/emitHtml';
+const template = readFileSync('myTemplate.mustache', 'utf8');
+const html = emitHtml(days, { template });
+```
+
+Copy and modify the default templates as a starting point.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "commander": "^14.0.0",
+        "mustache": "^4.2.0",
         "open-location-code": "^1.0.3",
         "seedrandom": "^3.0.5"
       },
@@ -2443,6 +2444,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "commander": "^14.0.0",
+    "mustache": "^4.2.0",
     "open-location-code": "^1.0.3",
     "seedrandom": "^3.0.5"
   },

--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'fs';
+import Mustache from 'mustache';
+import type { DayPlan } from '../types';
+
+const defaultTemplate = readFileSync(
+  new URL('./templates/itinerary.mustache', import.meta.url),
+  'utf8',
+);
+const defaultPartials = {
+  stop: readFileSync(new URL('./templates/stop.mustache', import.meta.url), 'utf8'),
+};
+
+export interface EmitHtmlOptions {
+  /** Override the base template */
+  template?: string;
+  /** Override or add partials */
+  partials?: Record<string, string>;
+}
+
+interface ViewModel {
+  days: {
+    dayId: string;
+    stops: {
+      arrive: string;
+      depart: string;
+      name: string;
+      type: string;
+      score?: string;
+    }[];
+  }[];
+}
+
+export function emitHtml(
+  days: DayPlan[],
+  opts: EmitHtmlOptions = {},
+): string {
+  const view: ViewModel = {
+    days: days.map((d) => ({
+      dayId: d.dayId,
+      stops: d.stops.map((s) => ({
+        arrive: s.arrive,
+        depart: s.depart,
+        name: s.name,
+        type: s.type,
+        score: s.score != null ? s.score.toFixed(1) : undefined,
+      })),
+    })),
+  };
+  const template = opts.template ?? defaultTemplate;
+  const partials = opts.partials ?? defaultPartials;
+  return Mustache.render(template, view, partials);
+}
+
+export default emitHtml;

--- a/src/io/templates/itinerary.mustache
+++ b/src/io/templates/itinerary.mustache
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Itinerary</title>
+  </head>
+  <body>
+    {{#days}}
+    <h2>Day {{dayId}}</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Arrive</th>
+          <th>Depart</th>
+          <th>Stop</th>
+          <th>Type</th>
+          <th>Score</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#stops}}
+        {{> stop}}
+        {{/stops}}
+      </tbody>
+    </table>
+    {{/days}}
+  </body>
+</html>

--- a/src/io/templates/stop.mustache
+++ b/src/io/templates/stop.mustache
@@ -1,0 +1,7 @@
+<tr>
+  <td>{{arrive}}</td>
+  <td>{{depart}}</td>
+  <td>{{name}}</td>
+  <td>{{type}}</td>
+  <td>{{score}}</td>
+</tr>

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { emitHtml } from '../src/io/emitHtml';
+import type { DayPlan } from '../src/types';
+
+describe('emitHtml', () => {
+  it('renders itinerary using template', () => {
+    const day: DayPlan = {
+      dayId: 'D1',
+      stops: [
+        { id: 'S', name: 'Start', type: 'start', arrive: '09:00', depart: '09:00', lat: 0, lon: 0 },
+        {
+          id: 'A',
+          name: 'Store A',
+          type: 'store',
+          arrive: '09:10',
+          depart: '09:20',
+          lat: 1,
+          lon: 2,
+          score: 1,
+        },
+        { id: 'E', name: 'End', type: 'end', arrive: '09:30', depart: '09:30', lat: 3, lon: 4 },
+      ],
+      metrics: {
+        storesVisited: 1,
+        totalScore: 1,
+        totalDriveMin: 0,
+        totalDwellMin: 0,
+        slackMin: 0,
+        onTimeRisk: 0,
+      },
+    };
+    const html = emitHtml([day]);
+    expect(html).toContain('<h2>Day D1</h2>');
+    expect(html).toContain('Store A');
+    // one row per stop inside tbody
+    const tbody = html.split('<tbody>')[1].split('</tbody>')[0];
+    const rows = tbody.match(/<tr>/g) || [];
+    expect(rows.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- render HTML itineraries using Mustache templates
- add default itinerary template and stop-row partial
- document template customization in README

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b230eca0288328a3088715c88d377e