### PR TITLE
docs: document new output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Utility for planning store visits.
 
+## Output Options
+
+The CLI prints itinerary JSON to stdout by default. Additional formats can
+be generated with flags:
+
+- `--out <file>` – write the JSON itinerary to a file.
+- `--csv <file>` – export store stops as CSV.
+- `--kml [file]` – emit a KML representation to a file or stdout.
+
 ## HTML Templates
 
 HTML itineraries are rendered with [Mustache](https://mustache.github.io/) templates.

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -27,6 +27,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 | `--done <ids>` | Comma-separated list of completed store IDs |
 | `--out <file>` | Write itinerary JSON to this path (overwrite) |
 | `--kml [file]` | Write KML to this path (or stdout) |
+| `--csv <file>` | Write store stops CSV to this path |
 | `--robustness <factor>` | Multiply travel times by this factor |
 | `--risk-threshold <min>` | Slack threshold minutes for on-time risk |
 
@@ -55,6 +56,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 
 - `--out <file>` – Writes the itinerary JSON to the specified path in addition to printing it to stdout, overwriting the file if it exists.
 - `--kml [file]` – Generates a KML representation. With a path argument, the KML is written to that file; otherwise, it is printed to stdout.
+- `--csv <file>` – Exports a CSV of store stops with arrival and departure times.
 
 ### Travel time adjustments and risk
 
@@ -63,14 +65,14 @@ rustbelt solve-day --trip <file> --day <id> [options]
 
 ## Output
 
-The solver prints the resulting itinerary as JSON. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided.
+The solver prints the resulting itinerary as JSON. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided. Using `--csv` saves a CSV of all store stops.
 
 ## Examples
 
-Solve a day and save the itinerary:
+Solve a day and save the itinerary and store stops:
 
 ```
-rustbelt solve-day --trip trips/example.json --day 2025-10-01 --out plans/day1.json
+rustbelt solve-day --trip trips/example.json --day 2025-10-01 --out plans/day1.json --csv plans/day1.csv
 ```
 
 Reoptimize from 1:30 PM at a specific location:

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -283,8 +283,10 @@ FR-16 (save/compare scenarios), FR-20 (why excluded \+ next-best).
   /io
 
     parse.ts          \# JSON/CSV import (stores, anchors)
-
     emit.ts           \# JSON/Markdown export of itinerary & metrics
+    emitHtml.ts       \# HTML itinerary rendering
+    emitKml.ts        \# KML export
+    emitCsv.ts        \# Store stop CSV export
 
   /app
 
@@ -698,11 +700,12 @@ node dist/index.js \\
 
     explain.ts         // Exclusions & swap analysis (v0.4)
 
-  /io
-
     parse.ts           // Trip/stores parsing; parseLocation()
 
     emit.ts            // JSON/Markdown outputs
+    emitHtml.ts        // HTML itinerary rendering
+    emitKml.ts         // KML export
+    emitCsv.ts         // Store stop CSV export
 
   /app
 
@@ -1014,7 +1017,7 @@ If metric is required later, gate it behind a single `units` flag and convert **
 3. `/src/schedule.ts` — `computeTimeline`, `isFeasible`, `slackMin`
 4. `/src/core/heuristics.ts` — seed → greedy insert (min feasible Δtime) → 2-opt/relocate; seeded tie-breaks  
 5. `/src/io/parse.ts` — `parseTrip`, `parseLocation` (lat/lon | Plus Code | URL `@lat,lon`), validation & dedupe  
-6. `/src/io/emit.ts` — JSON \+ optional Markdown summary with per-day metrics  
+6. `/src/io/emit.ts` — JSON \+ optional Markdown summary with per-day metrics; `emitHtml.ts` for HTML, `emitKml.ts` for KML, `emitCsv.ts` for CSV
 7. `/src/app/solveDay.ts` — orchestrate a single day solve  
 8. `/src/index.ts` — CLI entry (Commander): flags below
 

--- a/docs/rust-belt-test-plan.md
+++ b/docs/rust-belt-test-plan.md
@@ -27,7 +27,7 @@ jq . trips/rust-belt.json >/dev/null
 
 ## 2. Day-by-Day Runs
 
-Run the solver separately for each day. Use a fixed seed for reproducibility and the same average speed and dwell unless testing overrides.
+Run the solver separately for each day. Use a fixed seed for reproducibility and the same average speed and dwell unless testing overrides. Include `--csv` to capture a stop summary or `--kml` for a map view if desired.
 
 ### Day 1 – Detroit Loop
 
@@ -38,7 +38,8 @@ rustbelt solve-day \
   --mph 30 \
   --default-dwell 12 \
   --seed 1 \
-  --out plans/day1.json
+  --out plans/day1.json \
+  --csv plans/day1.csv
 ```
 
 **Expected checks**
@@ -72,7 +73,8 @@ rustbelt solve-day \
   --mph 30 \
   --default-dwell 12 \
   --seed 1 \
-  --out plans/day3.json
+  --out plans/day3.json \
+  --kml plans/day3.kml
 ```
 
 **Expected checks**
@@ -94,7 +96,8 @@ rustbelt solve-day \
   --at 41.6639,-83.5552 \
   --done s_021,s_045 \
   --seed 1 \
-  --out plans/day2-reopt.json
+  --out plans/day2-reopt.json \
+  --csv plans/day2-reopt.csv
 ```
 
 Verify that:


### PR DESCRIPTION
## Summary
- document JSON, CSV, and KML output flags in README and CLI docs
- note CSV/KML outputs in project plan and test plan

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2329d65048328969f97565460db07