### PR TITLE
feat: add HTML output option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { solveDay } from './app/solveDay';
 import { reoptimizeDay } from './app/reoptimizeDay';
 import { emitKml } from './io/emitKml';
 import { emitCsv } from './io/emitCsv';
+import { emitHtml } from './io/emitHtml';
 import { parseTrip } from './io/parse';
 import type { DayPlan, ID } from './types';
 import type { ProgressFn } from './heuristics';
@@ -47,6 +48,7 @@ program
   .option('--done <ids>', 'Comma-separated list of completed store IDs')
   .option('--out <file>', 'Write itinerary JSON to this path (overwrite)')
   .option('--kml [file]', 'Write KML to this path (or stdout)')
+  .option('--html [file]', 'Write HTML itinerary to this path (or stdout)')
   .option('--csv <file>', 'Write store stops CSV to this path')
   .option(
     '--robustness <factor>',
@@ -144,6 +146,17 @@ program
         console.log(`Wrote ${opts.kml}`);
       } else {
         console.log(kml);
+      }
+    }
+
+    if (opts.html !== undefined) {
+      const html = emitHtml(data.days);
+      if (typeof opts.html === 'string') {
+        mkdirSync(dirname(opts.html), { recursive: true });
+        writeFileSync(opts.html, html, 'utf8');
+        console.log(`Wrote ${opts.html}`);
+      } else {
+        console.log(html);
       }
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -35,6 +35,15 @@ describe('CLI', () => {
     );
   });
 
+  it('registers html flag for solve-day', () => {
+    const cmd = program.commands.find((c) => c.name() === 'solve-day');
+    const opt = cmd?.options.find((o) => o.long === '--html');
+    expect(opt).toBeDefined();
+    expect(opt?.description).toBe(
+      'Write HTML itinerary to this path (or stdout)',
+    );
+  });
+
   it('prints solution JSON by default', () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
@@ -53,6 +62,29 @@ describe('CLI', () => {
 
     expect(log).toHaveBeenCalledTimes(1);
     expect(() => JSON.parse(log.mock.calls[0][0])).not.toThrow();
+    log.mockRestore();
+  });
+
+  it('emits HTML when requested', () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const tripPath = join(__dirname, '../fixtures/simple-trip.json');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    run([
+      'node',
+      'rustbelt',
+      'solve-day',
+      '--trip',
+      tripPath,
+      '--day',
+      'D1',
+      '--html',
+    ]);
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(String(log.mock.calls[0][0])).toContain('<html>');
+    expect(() => JSON.parse(log.mock.calls[1][0])).not.toThrow();
     log.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- support `--html` flag for `solve-day` to emit itinerary as HTML
- document option in CLI help and route output to file or stdout
- test HTML output behavior

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build` *(fails: Could not find a declaration file for module 'mustache')*

------
https://chatgpt.com/codex/tasks/task_e_68b26dbd703c8328a968dce1a7080aaa