### PR TITLE
Expose stop tags in itinerary outputs

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -27,7 +27,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 | `--done <ids>`           | Comma-separated list of completed store IDs   |
 | `--out <file>`           | Write itinerary JSON to this path (overwrite) |
 | `--kml [file]`           | Write KML to this path (or stdout)            |
-| `--csv <file>`           | Write store stops CSV to this path            |
+| `--csv <file>`           | Write store stops CSV to this path (includes tags column) |
 | `--html [file]`          | Write HTML itinerary to this path or stdout   |
 | `--robustness <factor>`  | Multiply travel times by this factor          |
 | `--risk-threshold <min>` | Slack threshold minutes for on-time risk      |
@@ -64,6 +64,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 
 - Coordinates: For anchors and stores you can provide either numeric `lat`/`lon` or a `location` string. The `location` accepts `lat,lon`, a Plus Code, or a Google Maps URL containing `@lat,lon`.
 - Tags: Store `tags` may be an array of strings or a single string. When a string is provided, comma/semicolon/pipe separators are supported.
+  Tags are preserved in JSON, CSV, HTML, and KML outputs. The CSV export includes a `tags` column containing semicolon-separated values.
 - Day availability: If a store has a `dayId` field, it is only considered on that day.
 - Dedupe: When `config.snapDuplicateToleranceMeters` is set, stores within that distance are treated as duplicates and deduped on load.
 

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -286,7 +286,7 @@ FR-16 (save/compare scenarios), FR-20 (why excluded \+ next-best).
     emit.ts           \# JSON/Markdown export of itinerary & metrics
     emitHtml.ts       \# HTML itinerary rendering
     emitKml.ts        \# KML export
-    emitCsv.ts        \# Store stop CSV export
+    emitCsv.ts        \# Store stop CSV export (includes `tags` column with semicolon-separated tags; tags flow through all emitters)
 
   /app
 

--- a/src/io/emitCsv.ts
+++ b/src/io/emitCsv.ts
@@ -37,6 +37,7 @@ function stopToRow(
     leg?.driveMin != null ? String(leg.driveMin) : '',
     leg?.distanceMi != null ? String(leg.distanceMi) : '',
     stop.score != null ? String(stop.score) : '',
+    escapeCsv(stop.tags?.join(';') ?? ''),
   ];
   return cols.join(',');
 }
@@ -63,6 +64,7 @@ export function emitCsv(
     'drive_min',
     'distance_mi',
     'score',
+    'tags',
   ];
   const lines = [header.join(',')];
   for (const day of days) {

--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -26,6 +26,7 @@ interface ViewModel {
       name: string;
       type: string;
       score?: string;
+      tags?: string;
     }[];
   }[];
 }
@@ -43,6 +44,7 @@ export function emitHtml(
         name: s.name,
         type: s.type,
         score: s.score != null ? s.score.toFixed(1) : undefined,
+        tags: s.tags?.join(', '),
       })),
     })),
   };

--- a/src/io/emitKml.ts
+++ b/src/io/emitKml.ts
@@ -15,8 +15,13 @@ export function emitKml(days: DayPlan[]): string {
   const routeCoords: string[] = [];
   for (const day of days) {
     for (const stop of day.stops) {
+      const tags = stop.tags?.join(';');
+      const extended =
+        tags != null
+          ? `<ExtendedData><Data name="tags"><value>${escapeXml(tags)}</value></Data></ExtendedData>`
+          : '';
       placemarks.push(
-        `<Placemark><name>${escapeXml(stop.name)}</name><Point><coordinates>${stop.lon},${stop.lat},0</coordinates></Point></Placemark>`,
+        `<Placemark><name>${escapeXml(stop.name)}</name>${extended}<Point><coordinates>${stop.lon},${stop.lat},0</coordinates></Point></Placemark>`,
       );
       routeCoords.push(`${stop.lon},${stop.lat},0`);
     }

--- a/src/io/templates/itinerary.mustache
+++ b/src/io/templates/itinerary.mustache
@@ -14,6 +14,7 @@
           <th>Stop</th>
           <th>Type</th>
           <th>Score</th>
+          <th>Tags</th>
         </tr>
       </thead>
       <tbody>

--- a/src/io/templates/stop.mustache
+++ b/src/io/templates/stop.mustache
@@ -4,4 +4,5 @@
   <td>{{name}}</td>
   <td>{{type}}</td>
   <td>{{score}}</td>
+  <td>{{tags}}</td>
 </tr>

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -180,6 +180,7 @@ export function computeTimeline(order: ID[], ctx: ScheduleCtx): TimelineResult {
         distanceMi: dist,
       },
       score: store.score,
+      tags: store.tags,
     });
 
     currentId = store.id;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface StopPlan {
   dwellMin?: number;
   legIn?: Leg;
   score?: number;
+  tags?: string[];
 }
 
 export interface DayPlan {


### PR DESCRIPTION
## Summary
- carry store tags into StopPlan and timeline
- include tags in CSV, HTML, and KML outputs
- document that tags are preserved across outputs and add CSV column details

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3096ba43483289bf5ec8abee6d31f