### PR TITLE
Enhance KML output with detailed extended data

### DIFF
--- a/src/io/emitKml.ts
+++ b/src/io/emitKml.ts
@@ -15,11 +15,25 @@ export function emitKml(days: DayPlan[]): string {
   const routeCoords: string[] = [];
   for (const day of days) {
     for (const stop of day.stops) {
-      const tags = stop.tags?.join(';');
-      const extended =
-        tags != null
-          ? `<ExtendedData><Data name="tags"><value>${escapeXml(tags)}</value></Data></ExtendedData>`
-          : '';
+      const details: [string, string | number | undefined][] = [
+        ['id', stop.id],
+        ['type', stop.type],
+        ['arrive', stop.arrive],
+        ['depart', stop.depart],
+        ['score', stop.score],
+        ['driveMin', stop.legIn?.driveMin],
+        ['distanceMi', stop.legIn?.distanceMi],
+        ['dwellMin', stop.dwellMin],
+        ['tags', stop.tags?.join(';')],
+      ];
+      const data = details
+        .filter(([, value]) => value !== undefined)
+        .map(
+          ([name, value]) =>
+            `<Data name="${name}"><value>${escapeXml(String(value))}</value></Data>`,
+        )
+        .join('');
+      const extended = data ? `<ExtendedData>${data}</ExtendedData>` : '';
       placemarks.push(
         `<Placemark><name>${escapeXml(stop.name)}</name>${extended}<Point><coordinates>${stop.lon},${stop.lat},0</coordinates></Point></Placemark>`,
       );


### PR DESCRIPTION
## Summary
- Populate KML placemarks with rich ExtendedData including IDs, timing, metrics, and tags
- Build ExtendedData dynamically by filtering undefined values and escaping XML

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build` *(fails: Could not find declaration file for module 'seedrandom', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b672f3cbb883288eaa344a08e64b83