### PR TITLE
Document KML extended data fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ be generated with flags:
 - `--kml [file]` – emit a KML representation to a file or stdout.
 - `--html [file]` – emit an HTML itinerary to a file or stdout. Templates can be customized via `emitHtml`.
 
+The KML output includes an `<ExtendedData>` block for each stop. Placemarks
+expose fields such as `id`, `type`, `arrive`, `depart`, `score`, `driveMin`,
+`distanceMi`, `dwellMin`, and `tags`:
+
+```xml
+<Placemark>
+  <name>Example Store</name>
+  <ExtendedData>
+    <Data name="id"><value>123</value></Data>
+    <Data name="arrive"><value>2025-10-01T10:00:00Z</value></Data>
+    <Data name="driveMin"><value>12</value></Data>
+  </ExtendedData>
+  <Point><coordinates>-81.7,41.5,0</coordinates></Point>
+</Placemark>
+```
+
+Applications like Google Earth surface these properties in a placemark's
+**Properties/Get Info** window, and they can be accessed programmatically by
+parsing the `<ExtendedData>` entries.
+
 ## HTML Templates
 
 HTML itineraries are rendered with [Mustache](https://mustache.github.io/) templates.

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -56,9 +56,28 @@ rustbelt solve-day --trip <file> --day <id> [options]
 ### Output format flags
 
 - `--out <file>` – Writes the itinerary JSON to the specified path in addition to printing it to stdout, overwriting the file if it exists.
-- `--kml [file]` – Generates a KML representation. With a path argument, the KML is written to that file; otherwise, it is printed to stdout.
+- `--kml [file]` – Generates a KML representation with stop data in `<ExtendedData>`. With a path argument, the KML is written to that file; otherwise, it is printed to stdout.
 - `--csv <file>` – Exports a CSV of store stops with arrival and departure times.
 - `--html [file]` – Emits an HTML itinerary to the given file or to stdout. Templates can be customized via `emitHtml`.
+
+Each KML placemark contains an `<ExtendedData>` block listing fields such as
+`id`, `type`, `arrive`, `depart`, `score`, `driveMin`, `distanceMi`,
+`dwellMin`, and `tags`:
+
+```xml
+<Placemark>
+  <name>Example Store</name>
+  <ExtendedData>
+    <Data name="id"><value>123</value></Data>
+    <Data name="depart"><value>2025-10-01T10:15:00Z</value></Data>
+    <Data name="tags"><value>priority;promo</value></Data>
+  </ExtendedData>
+</Placemark>
+```
+
+Consumers like Google Earth expose these values in the placemark's
+**Properties/Get Info** dialog and they can be read programmatically by parsing
+the `<ExtendedData>` entries.
 
 ## Trip file notes
 


### PR DESCRIPTION
## Summary
- document KML ExtendedData fields and example snippet
- note how tools like Google Earth access stop metadata

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f1559c1c8328a3c567a5502b794f