### PR TITLE
Honor must-visit store tags in day plans

### DIFF
--- a/fixtures/tagged-must-visit.json
+++ b/fixtures/tagged-must-visit.json
@@ -1,0 +1,17 @@
+{
+  "config": { "mph": 60, "defaultDwellMin": 0, "seed": 1 },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "E", "name": "end", "lat": 0.4, "lon": 0 },
+      "window": { "start": "08:00", "end": "09:40" }
+    }
+  ],
+  "stores": [
+    { "id": "A", "name": "A", "lat": 0.1, "lon": 0 },
+    { "id": "B", "name": "B", "lat": 0.2, "lon": 0 },
+    { "id": "C", "name": "C", "lat": 0.3, "lon": 0 },
+    { "id": "D", "name": "D", "lat": 0, "lon": 0.6, "tags": ["must-visit"] }
+  ]
+}

--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -85,7 +85,20 @@ export function solveCommon(opts: SolveCommonOptions): DayPlan {
     candidateIds = candidateIds.filter((id) => !done.has(id));
   }
 
-  let mustVisitIds = day.mustVisitIds?.filter((id) => candidateIds.includes(id));
+  let mustVisitIds: ID[] | undefined = day.mustVisitIds?.filter((id) =>
+    candidateIds.includes(id),
+  );
+  const taggedMustVisitIds = candidateIds.filter((id) =>
+    (stores[id].tags ?? []).some((t) => /must[-_]?visit/i.test(t)),
+  );
+  if (taggedMustVisitIds.length > 0) {
+    mustVisitIds = [
+      ...new Set([...(mustVisitIds ?? []), ...taggedMustVisitIds]),
+    ];
+  }
+  if (mustVisitIds && mustVisitIds.length === 0) {
+    mustVisitIds = undefined;
+  }
   let locks = (opts.locks ?? day.locks)?.filter((l) => candidateIds.includes(l.storeId));
 
   if (day.breakWindow) {

--- a/tests/must-visit-tag.test.ts
+++ b/tests/must-visit-tag.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { solveDay } from '../src/app/solveDay';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('must-visit tags', () => {
+  it('includes stores tagged must-visit in the plan', () => {
+    const tripPath = join(__dirname, '../fixtures/tagged-must-visit.json');
+    const result = solveDay({ tripPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    const ids = data.days[0].stops.map((s: { id: string }) => s.id);
+    expect(ids).toEqual(['S', 'D', 'B', 'C', 'E']);
+    expect(data.days[0].metrics.storesVisited).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- consider store tags matching `must-visit` when assembling required stops
- add fixture and test to ensure tagged stores are included in the itinerary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beeddbc59483288b2048d204799a75