### PR TITLE
Add setup docs and fix build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 Utility for planning store visits.
 
+## Getting Started
+
+1. **Install dependencies**
+   ```sh
+   npm install
+   ```
+2. **Build the CLI**
+   ```sh
+   npm run build
+   ```
+   This compiles TypeScript sources to `dist/`.
+3. **Run a solve**
+   ```sh
+   npx tsx src/index.ts solve-day --trip trips/example.json --day 2025-10-01
+   ```
+   After building you can also run:
+   ```sh
+   node dist/index.js solve-day --trip trips/example.json --day 2025-10-01
+   ```
+
+## Documentation
+
+- [CLI usage](docs/rust-belt-cli-documentation.md)
+- [Trip schema](docs/trip-schema.json)
+- [Test plan](docs/rust-belt-test-plan.md)
+- [Route planner roadmap](docs/rust-belt-route-planner.md)
+
 ## Output Options
 
 The CLI prints itinerary JSON to stdout by default. Additional formats can

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -2,6 +2,19 @@
 
 This document describes how to use the `rustbelt` command-line interface.
 
+## Setup
+
+Install dependencies and run the CLI either directly from the TypeScript
+sources or from the compiled JavaScript.
+
+```sh
+npm install
+npx tsx src/index.ts --help    # run from source
+# or
+npm run build
+node dist/index.js --help      # run after build
+```
+
 ## Usage
 
 ```
@@ -109,3 +122,8 @@ Reoptimize from 1:30 PM at a specific location:
 ```
 rustbelt solve-day --trip trips/example.json --day 2025-10-01 --now 13:30 --at 41.5,-81.7
 ```
+
+## See also
+
+- [Trip schema](trip-schema.json) – structure of trip JSON files
+- [Test plan](rust-belt-test-plan.md) – walkthrough of typical commands

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -1,5 +1,8 @@
 # Project: Multi-Day Thrift Route Planner (OPTW-lite)
 
+See [CLI usage](rust-belt-cli-documentation.md) for command details and the
+[trip schema](trip-schema.json) for input structure.
+
 ## Problem Frame & Goals
 
 - **Goal:** Build a planner that **maximizes number of stores visited per day** on a multi-day Detroit → Cleveland (overnight) → Buffalo (overnight) trip, with fixed daily start/end anchors and simple travel modeling.  
@@ -10,7 +13,7 @@
 
 FRs broken down by implementation milestone (v0.x)
 
-## v0.1 — Core Day-By-Day Planner (MVP)
+## v0.1 — Core Day-By-Day Planner (MVP) — Implemented
 
 - **FR-1** Multi-day segmentation by day (**backtracking allowed**)  
 - **FR-3** Auto partitioning into day subroutes  
@@ -28,7 +31,7 @@ FRs broken down by implementation milestone (v0.x)
 - **FR-30** Feasibility fixtures  
 - **FR-31** Regression baselines
 
-## v0.2 — Usability & Resilience
+## v0.2 — Usability & Resilience — In progress
 
 - **FR-14** Lock/Pin stops  
 - **FR-21** **Live mid-day re-optimization** (current time/location \+ hotel)  
@@ -36,14 +39,14 @@ FRs broken down by implementation milestone (v0.x)
 - **FR-18** Fuller diagnostics (bottlenecks)  
 - **FR-28** Expose **best-so-far** solution & progress
 
-## v0.3 — Power Controls & Robustness
+## v0.3 — Power Controls & Robustness — Planned
 
 - **FR-5** Objective: **score/utility** mode (or blend)  
 - **FR-12** Daily caps (max drive/stops) & optional break window  
  
 - **FR-22** Robustness buffers & **On-Time Risk**
 
-## v0.4 — Explainability & Scenarios (Stretch)
+## v0.4 — Explainability & Scenarios (Stretch) — Planned
 
 - **FR-16** Save/compare scenarios  
 - **FR-20** Why-excluded \+ next-best alternative
@@ -78,7 +81,7 @@ FRs broken down by implementation milestone (v0.x)
 
 ---
 
-## v0.1 — Core Day-By-Day Planner (MVP)
+## v0.1 — Core Day-By-Day Planner (MVP) (implemented)
 
 **FRs included:**  
 FR-1 (day segmentation; backtracking allowed), FR-3, FR-4, FR-6 (basic tie-breakers), FR-8, FR-9 (Haversine+mph), FR-11 (must-visit), FR-17, FR-18 (basic), FR-24, FR-25, FR-28 (size target), FR-29, FR-30, FR-31.
@@ -94,7 +97,7 @@ FR-1 (day segmentation; backtracking allowed), FR-3, FR-4, FR-6 (basic tie-break
 
 ---
 
-## v0.2 — Usability & Resilience
+## v0.2 — Usability & Resilience (in progress)
 
 **FRs included:**  
 FR-14 (lock/pin), FR-21 (mid-day re-opt), FR-13 (infeasibility & minimal relaxation), FR-18 (full diagnostics), FR-28 (best-so-far/progress).
@@ -108,7 +111,7 @@ FR-14 (lock/pin), FR-21 (mid-day re-opt), FR-13 (infeasibility & minimal relaxat
 
 ---
 
-## v0.3 — Power Controls & Robustness
+## v0.3 — Power Controls & Robustness (planned)
 
 **FRs included:**  
 FR-5 (score/utility objective mode), FR-12 (daily limits: max drive time/stops; optional break window; defaults off), FR-22 (robustness buffers \+ risk view).
@@ -123,7 +126,7 @@ FR-5 (score/utility objective mode), FR-12 (daily limits: max drive time/stops; 
 
 ---
 
-## v0.4 — Explainability & Scenario Mgmt (Stretch)
+## v0.4 — Explainability & Scenario Mgmt (planned)
 
 **FRs included:**  
 FR-16 (save/compare scenarios), FR-20 (why excluded \+ next-best).
@@ -1013,9 +1016,9 @@ If metric is required later, gate it behind a single `units` flag and convert **
 ## C. Implement First (file order)
 
 1. `/src/distance.ts` — `haversineMiles`, `minutesAtMph`, `buildMatrix()`
-2. `/src/core/types.ts` — types in §6.2 (imperial-only)  
+2. `/src/types.ts` — types in §6.2 (imperial-only)
 3. `/src/schedule.ts` — `computeTimeline`, `isFeasible`, `slackMin`
-4. `/src/core/heuristics.ts` — seed → greedy insert (min feasible Δtime) → 2-opt/relocate; seeded tie-breaks  
+4. `/src/heuristics.ts` — seed → greedy insert (min feasible Δtime) → 2-opt/relocate; seeded tie-breaks
 5. `/src/io/parse.ts` — `parseTrip`, `parseLocation` (lat/lon | Plus Code | URL `@lat,lon`), validation & dedupe  
 6. `/src/io/emit.ts` — JSON \+ optional Markdown summary with per-day metrics; `emitHtml.ts` for HTML, `emitKml.ts` for KML, `emitCsv.ts` for CSV
 7. `/src/app/solveDay.ts` — orchestrate a single day solve  

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "seedrandom": "^3.0.5"
       },
       "devDependencies": {
+        "@types/mustache": "^4.2.6",
         "@types/node": "^24.3.0",
         "@types/open-location-code": "^1.0.1",
+        "@types/seedrandom": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
         "@xmldom/xmldom": "^0.8.11",
@@ -1077,6 +1079,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mustache": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.6.tgz",
+      "integrity": "sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -1091,6 +1100,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/open-location-code/-/open-location-code-1.0.1.tgz",
       "integrity": "sha512-txJKhrRpT2fw8RgZQUeT6qycBVIzRQ2zD7ecdLvc5R2QaeqSLcYIh1jxLSC+LjcpUT26Qyfw2UTttmhgk3sWmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/seedrandom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.8.tgz",
+      "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "seedrandom": "^3.0.5"
   },
   "devDependencies": {
+    "@types/mustache": "^4.2.6",
     "@types/node": "^24.3.0",
     "@types/open-location-code": "^1.0.1",
+    "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
     "@xmldom/xmldom": "^0.8.11",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "outDir": "dist",
     "sourceMap": true
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }
  


### PR DESCRIPTION
## Summary
- document installation, build steps, and CLI entry points
- link project docs and annotate roadmap with current status
- add type definitions for `seedrandom` and `mustache` to fix `npm run build`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf37408b0083289f0a89c38a77bc5b