### PR TITLE
Add run timestamp to itinerary outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ to `emitHtml`:
 import { readFileSync } from 'fs';
 import { emitHtml } from './src/io/emitHtml';
 const template = readFileSync('myTemplate.mustache', 'utf8');
-const html = emitHtml(days, { template });
+const runTs = new Date().toISOString();
+const html = emitHtml(days, runTs, { template });
 ```
 
 Copy and modify the default templates as a starting point.

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -107,7 +107,7 @@ the `<ExtendedData>` entries.
 
 ## Output
 
-The solver prints the resulting itinerary as JSON. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided. Using `--csv` saves a CSV of all store stops. Passing `--html` writes an HTML itinerary to the given file or stdout; templates can be customized via `emitHtml`.
+The solver prints the resulting itinerary as JSON, including a `runTimestamp` field for tracking when the plan was generated. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided. Using `--csv` saves a CSV of all store stops. Passing `--html` writes an HTML itinerary to the given file or stdout; templates can be customized via `emitHtml`.
 
 ## Examples
 

--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -41,7 +41,8 @@ export function reoptimizeDay(
       riskThresholdMin: opts.riskThresholdMin,
     });
 
-    return emitItinerary([dayPlan]);
+    const runTimestamp = new Date().toISOString();
+    return emitItinerary([dayPlan], runTimestamp);
   } catch (err) {
     throw augmentErrorWithReasons(err);
   }

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -36,7 +36,8 @@ export function solveDay(opts: SolveDayOptions): SolveDayResult {
       robustnessFactor: opts.robustnessFactor,
       riskThresholdMin: opts.riskThresholdMin,
     });
-    const emit = emitItinerary([dayPlan]);
+    const runTimestamp = new Date().toISOString();
+    const emit = emitItinerary([dayPlan], runTimestamp);
     return { ...emit, metrics: dayPlan.metrics };
   } catch (err) {
     throw augmentErrorWithReasons(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,11 @@ program
       });
     }
 
-    const data = JSON.parse(result.json) as { days: DayPlan[] };
+    const data = JSON.parse(result.json) as {
+      runTimestamp: string;
+      days: DayPlan[];
+    };
+    const runTs = result.runTimestamp;
 
     if (opts.out) {
       mkdirSync(dirname(opts.out), { recursive: true });
@@ -115,7 +119,6 @@ program
     }
 
     if (opts.csv) {
-      const runTs = new Date().toISOString();
       const rawTrip = readFileSync(opts.trip, 'utf8');
       const trip = parseTrip(JSON.parse(rawTrip));
       const mustVisitByDay: Record<string, ReadonlySet<ID>> = {};
@@ -139,7 +142,7 @@ program
     }
 
     if (opts.kml !== undefined) {
-      const kml = emitKml(data.days);
+      const kml = emitKml(data.days, runTs);
       if (typeof opts.kml === 'string') {
         mkdirSync(dirname(opts.kml), { recursive: true });
         writeFileSync(opts.kml, kml, 'utf8');
@@ -150,7 +153,7 @@ program
     }
 
     if (opts.html !== undefined) {
-      const html = emitHtml(data.days);
+      const html = emitHtml(data.days, runTs);
       if (typeof opts.html === 'string') {
         mkdirSync(dirname(opts.html), { recursive: true });
         writeFileSync(opts.html, html, 'utf8');

--- a/src/io/emit.ts
+++ b/src/io/emit.ts
@@ -7,6 +7,7 @@ export interface EmitOptions {
 
 export interface EmitResult {
   json: string;
+  runTimestamp: string;
   markdown?: string;
 }
 
@@ -32,10 +33,11 @@ function toMarkdown(days: DayPlan[]): string {
 /** Serialize per-day itineraries to JSON and optional Markdown summary. */
 export function emitItinerary(
   days: DayPlan[],
+  runTimestamp = new Date().toISOString(),
   opts: EmitOptions = {},
 ): EmitResult {
-  const json = JSON.stringify({ days }, null, 2);
-  const result: EmitResult = { json };
+  const json = JSON.stringify({ runTimestamp, days }, null, 2);
+  const result: EmitResult = { json, runTimestamp };
   if (opts.markdown) {
     result.markdown = toMarkdown(days);
   }
@@ -43,7 +45,10 @@ export function emitItinerary(
 }
 
 export { toMarkdown as emitMarkdown };
-export function emitJson(days: DayPlan[]): string {
-  return JSON.stringify({ days }, null, 2);
+export function emitJson(
+  days: DayPlan[],
+  runTimestamp = new Date().toISOString(),
+): string {
+  return JSON.stringify({ runTimestamp, days }, null, 2);
 }
 

--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -33,9 +33,11 @@ interface ViewModel {
 
 export function emitHtml(
   days: DayPlan[],
+  runTimestamp = new Date().toISOString(),
   opts: EmitHtmlOptions = {},
 ): string {
-  const view: ViewModel = {
+  const view: ViewModel & { runTimestamp: string } = {
+    runTimestamp,
     days: days.map((d) => ({
       dayId: d.dayId,
       stops: d.stops.map((s) => ({

--- a/src/io/emitKml.ts
+++ b/src/io/emitKml.ts
@@ -10,7 +10,10 @@ function escapeXml(s: string): string {
 }
 
 /** Serialize itinerary stops to KML. */
-export function emitKml(days: DayPlan[]): string {
+export function emitKml(
+  days: DayPlan[],
+  runTimestamp = new Date().toISOString(),
+): string {
   const placemarks: string[] = [];
   const routeCoords: string[] = [];
   for (const day of days) {
@@ -45,6 +48,7 @@ export function emitKml(days: DayPlan[]): string {
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<kml xmlns="http://www.opengis.net/kml/2.2">',
     '<Document>',
+    `<ExtendedData><Data name="runTimestamp"><value>${escapeXml(runTimestamp)}</value></Data></ExtendedData>`,
     ...placemarks,
     route,
     '</Document>',

--- a/src/io/templates/itinerary.mustache
+++ b/src/io/templates/itinerary.mustache
@@ -4,6 +4,7 @@
     <title>Itinerary</title>
   </head>
   <body>
+    <p>Run timestamp: {{runTimestamp}}</p>
     {{#days}}
     <h2>Day {{dayId}}</h2>
     <table>

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -29,9 +29,11 @@ describe('emitHtml', () => {
         onTimeRisk: 0,
       },
     };
-    const html = emitHtml([day]);
+    const runTs = '2024-01-01T00:00:00Z';
+    const html = emitHtml([day], runTs);
     expect(html).toContain('<h2>Day D1</h2>');
     expect(html).toContain('Store A');
+    expect(html).toContain(runTs);
     // one row per stop inside tbody
     const tbody = html.split('<tbody>')[1].split('</tbody>')[0];
     const rows = tbody.match(/<tr>/g) || [];

--- a/tests/emitKml.test.ts
+++ b/tests/emitKml.test.ts
@@ -14,11 +14,18 @@ describe('emitKml', () => {
     const tripPath = join(__dirname, '../fixtures/simple-trip.json');
     const result = solveDay({ tripPath, dayId: 'D1' });
     const data = JSON.parse(result.json) as { days: DayPlan[] };
-    const kml = emitKml(data.days);
+    const runTs = result.runTimestamp;
+    const kml = emitKml(data.days, runTs);
     const doc = new DOMParser().parseFromString(kml, 'text/xml');
     const placemarks = doc.getElementsByTagName('Placemark');
     expect(placemarks.length).toBe(data.days[0].stops.length + 1);
     expect(doc.getElementsByTagName('LineString').length).toBe(1);
+    const docExt = doc
+      .getElementsByTagName('Document')[0]
+      .getElementsByTagName('ExtendedData')[0];
+    expect(
+      docExt.getElementsByTagName('value')[0].textContent,
+    ).toBe(runTs);
   });
 
   it('includes extended data for each stop', () => {
@@ -26,7 +33,8 @@ describe('emitKml', () => {
     const result = solveDay({ tripPath, dayId: 'D1' });
     const data = JSON.parse(result.json) as { days: DayPlan[] };
     const stop = data.days[0].stops[1]; // first real stop (after start)
-    const kml = emitKml(data.days);
+    const runTs = result.runTimestamp;
+    const kml = emitKml(data.days, runTs);
     const doc = new DOMParser().parseFromString(kml, 'text/xml');
     const placemark = doc.getElementsByTagName('Placemark')[1];
     const extended = placemark.getElementsByTagName('ExtendedData')[0];
@@ -73,7 +81,8 @@ describe('emitKml', () => {
       },
     ];
 
-    const kml = emitKml(days);
+    const runTs = '2024-01-01T00:00:00Z';
+    const kml = emitKml(days, runTs);
     const doc = new DOMParser().parseFromString(kml, 'text/xml');
     const extended = doc
       .getElementsByTagName('Placemark')[0]

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -16,6 +16,7 @@ describe('solveDay', () => {
     const tripPath = join(__dirname, '../fixtures/simple-trip.json');
     const result = solveDay({ tripPath, dayId: 'D1' });
     const data = JSON.parse(result.json);
+    expect(typeof data.runTimestamp).toBe('string');
     const ids = data.days[0].stops.map((s: { id: string }) => s.id);
     expect(ids).toEqual(['S', 'A', 'B', 'C', 'E']);
     expect(data.days[0].metrics.storesVisited).toBe(3);
@@ -25,7 +26,9 @@ describe('solveDay', () => {
   it('produces stable itinerary output (FR-31)', () => {
     const tripPath = join(__dirname, '../fixtures/simple-trip.json');
     const result = solveDay({ tripPath, dayId: 'D1' });
-    expect(JSON.parse(result.json)).toMatchSnapshot();
+    const data = JSON.parse(result.json);
+    delete data.runTimestamp;
+    expect(data).toMatchSnapshot();
   });
 
   it('respects store scores when lambda=1', () => {


### PR DESCRIPTION
## Summary
- include `runTimestamp` in JSON itinerary outputs
- surface run timestamp in HTML and KML files
- thread run timestamp through CLI and document usage

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: The file was not found in any of the provided project(s))*

------
https://chatgpt.com/codex/tasks/task_e_68c234e4a1a88328a74df435641b5d47