### PR TITLE
feat: include store address in trip schema

### DIFF
--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -49,6 +49,7 @@
           "type": "string",
           "description": "Alternative to lat/lon; accepts 'lat,lon', Plus Codes, or a Google Maps URL containing @lat,lon"
         },
+        "address": { "type": "string", "description": "Street address for the store" },
         "dwellMin": { "type": "number", "description": "Minutes spent at this stop (overrides defaults)" },
         "score": { "type": "number", "description": "Optional utility score used when blending or maximizing score" },
         "tags": {


### PR DESCRIPTION
## Summary
- allow trip data to specify an optional store address in trip-schema.json

## Testing
- `npm test -- --run`
- `npm run lint` (fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)
- `npx eslint src --ext .ts`


------
https://chatgpt.com/codex/tasks/task_e_68c36f05bb6c83288ef8c15fb621ad82