### PR TITLE
Document store hours support

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -1,6 +1,6 @@
 # Rust Belt CLI
 
-This document describes how to use the `rustbelt` command-line interface.
+This document describes how to use the `rustbelt` command-line interface. The solver honors per‑store open hours so that closed locations are never scheduled.
 
 ## Setup
 
@@ -98,6 +98,7 @@ the `<ExtendedData>` entries.
 - Tags: Store `tags` may be an array of strings or a single string. When a string is provided, comma/semicolon/pipe separators are supported.
   Tags are preserved in JSON, CSV, HTML, and KML outputs. The CSV export includes a `tags` column containing semicolon-separated values.
 - Day availability: If a store has a `dayId` field, it is only considered on that day.
+- Store hours: Each day must specify a `dayOfWeek` (e.g., "Monday"). Stores may include an `openHours` object mapping weekday codes to arrays of `[open, close]` windows. The solver only visits a store when the arrival and dwell fit within one of that day's windows. Missing entries mean the store is closed, while omitting `openHours` makes the store always available.
 - Dedupe: When `config.snapDuplicateToleranceMeters` is set, stores within that distance are treated as duplicates and deduped on load.
 
 ### Travel time adjustments and risk

--- a/docs/rust-belt-output-guide.md
+++ b/docs/rust-belt-output-guide.md
@@ -1,6 +1,6 @@
 # Rust Belt Output Guide
 
-This page explains how to interpret the JSON produced by `rustbelt solve-day` and how configuration options influence the itinerary. The examples reference the sample output below.
+This page explains how to interpret the JSON produced by `rustbelt solve-day` and how configuration options influence the itinerary. When stores declare `openHours`, the solver only visits them within those windows and omits closed locations. The examples reference the sample output below.
 
 ```json
 {
@@ -21,7 +21,7 @@ This page explains how to interpret the JSON produced by `rustbelt solve-day` an
 Each element in the `stops` array represents a location in the itinerary. Fields include:
 
 - `id`, `name`, and `type` (`start`, `store`, or `end`).
-- `arrive` and `depart` times in local time.
+- `arrive` and `depart` times in local time. When a store defines `openHours`, these times always fall within one of its windows.
 - Geographic coordinates `lat` and `lon`.
 - Optional `address` with the store's street address (store stops only).
 - Optional `dwellMin` showing minutes planned at the stop.

--- a/docs/rust-belt-test-plan.md
+++ b/docs/rust-belt-test-plan.md
@@ -13,8 +13,8 @@ The steps below exercise the CLI, verify itinerary outputs, and ensure no store 
 ## 1. Prepare Data
 
 1. Build a trip JSON (`trips/rust-belt.json`) with:
-   - Three `dayId` entries with start/end anchors and time windows matching the legs above.
-   - A `stores` array containing all 132 stores with unique `id` values. Optionally assign a `dayId` to restrict a store to a single day; stores without a `dayId` are candidates on every day. Stores should appear **only once** in the file.
+   - Three `dayId` entries with start/end anchors, time windows, and `dayOfWeek` values matching the legs above.
+   - A `stores` array containing all 132 stores with unique `id` values. Optionally assign a `dayId` to restrict a store to a single day; stores without a `dayId` are candidates on every day. Include `openHours` for a few stores to test the hours logic; stores without this field are treated as open all day. Stores should appear **only once** in the file.
 2. Optional: group stores roughly by geography to balance the daily workload (e.g., Detroit downtown vs. suburbs).
 3. Validate the JSON with `jq` or the provided schema (`docs/trip-schema.json`) before solving.
 
@@ -81,6 +81,14 @@ rustbelt solve-day \
 - Itinerary covers stores from Cleveland through Buffalo only.
 - No duplicates from earlier days.
 - Final stop is the Buffalo hotel with feasible slack.
+
+---
+
+### Store hours
+
+Include at least one store whose `openHours` do not cover the predicted arrival time (e.g., closed for lunch). After solving each day, verify that:
+- The solver skips stores closed on the target day or outside their hours.
+- All visited stops have `arrive`/`depart` times within one of their open windows.
 
 ---
 

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -62,7 +62,16 @@
         "dayId": { "type": "string", "description": "If present, store is only available on this day" },
         "openHours": {
           "type": "object",
-          "description": "Maps weekday codes (mon-sun) to arrays of [open, close] times"
+          "description": "Maps weekday codes (mon-sun) to arrays of [open, close] times",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          }
         }
       },
       "oneOf": [
@@ -137,7 +146,11 @@
         },
         "robustnessFactor": { "type": "number", "description": "Multiply drive times to add buffer (e.g., 1.1 = +10%)" },
         "riskThresholdMin": { "type": "number", "description": "Slack threshold minutes for on-time risk metric" },
-        "dayOfWeek": { "type": "string", "description": "Day of week for applying store open hours" }
+        "dayOfWeek": {
+          "type": "string",
+          "description": "Day of week for applying store open hours",
+          "enum": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        }
       }
     },
     "TripConfig": {


### PR DESCRIPTION
## Summary
- Note that the CLI and solver respect per-store open hours
- Add store-hours feature and examples to the route-planner design
- Extend trip schema and test plan for `openHours` and `dayOfWeek`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c62f9febd48328b7e5811ae4dc8a6d