### PR TITLE
docs: clarify openHours empty arrays mark store closed

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -98,7 +98,7 @@ the `<ExtendedData>` entries.
 - Tags: Store `tags` may be an array of strings or a single string. When a string is provided, comma/semicolon/pipe separators are supported.
   Tags are preserved in JSON, CSV, HTML, and KML outputs. The CSV export includes a `tags` column containing semicolon-separated values.
 - Day availability: If a store has a `dayId` field, it is only considered on that day.
-- Store hours: Each day must specify a `dayOfWeek` (e.g., "Monday"). Stores may include an `openHours` object mapping weekday codes to arrays of `[open, close]` windows. The solver only visits a store when the arrival and dwell fit within one of that day's windows. Missing entries mean the store is closed, while omitting `openHours` makes the store always available.
+- Store hours: Each day must specify a `dayOfWeek` (e.g., "Monday"). Stores may include an `openHours` object mapping weekday codes to arrays of `[open, close]` windows. The solver only visits a store when the arrival and dwell fit within one of that day's windows. Missing entries mean the store is closed, and providing an empty array for a weekday also marks the store as closed on that day, while omitting `openHours` makes the store always available.
 - Dedupe: When `config.snapDuplicateToleranceMeters` is set, stores within that distance are treated as duplicates and deduped on load.
 
 ### Travel time adjustments and risk


### PR DESCRIPTION
## Summary
- explain that empty `openHours` arrays also mark a store closed for that day

## Testing
- `npm test`
- `npm run lint` *(fails: parserOptions.project has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c64ab7da108328ad5ff318ca2390fb