### PR TITLE
Allow openHours times without leading zero

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -35,7 +35,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 | `--lambda <lambda>`      | Score weighting (0=count,1=score)             |
 | `--verbose`              | Print heuristic steps                         |
 | `--progress`             | Print heuristic progress                      |
-| `--now <HH:mm>`          | Reoptimize from this time                     |
+| `--now <HH:mm>`          | Reoptimize from this time (leading zero optional) |
 | `--at <lat,lon>`         | Current location                              |
 | `--done <ids>`           | Comma-separated list of completed store IDs   |
 | `--out <file>`           | Write itinerary JSON to this path (overwrite) |
@@ -64,7 +64,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 
 ### Reoptimization flags
 
-- `--now <HH:mm>` and `--at <lat,lon>` – When both flags are supplied, the solver reoptimizes the remainder of the day starting from the given time and location. Any IDs passed with `--done <ids>` are excluded from further consideration. If only one of `--now` or `--at` is provided, the solver starts from the day's original start and ignores the reoptimization parameters.
+- `--now <HH:mm>` (leading zero optional) and `--at <lat,lon>` – When both flags are supplied, the solver reoptimizes the remainder of the day starting from the given time and location. Any IDs passed with `--done <ids>` are excluded from further consideration. If only one of `--now` or `--at` is provided, the solver starts from the day's original start and ignores the reoptimization parameters.
 
 ### Output format flags
 

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -546,12 +546,12 @@ To avoid manual “completed IDs” while driving, support three modes; the solv
 
 **Mode 1 — Schedule-based inference (zero overhead)**
 
-- **Inputs:** `--now HH:mm`  
+- **Inputs:** `--now HH:mm` (leading zero optional)
 - **Logic:** Treat any stops with \*\*planned `depart ≤ now` as completed.
 
 **Mode 2 — Location snap (recommended)**
 
-- **Inputs:** `--now HH:mm --at "<lat>,<lon>"`  
+- **Inputs:** `--now HH:mm --at "<lat>,<lon>"` (leading zero optional)
 - **Logic:** Snap `--at` to the nearest planned stop within radius **R** (default 120 m). Inside a stop → mark it current/completed; otherwise treat as in-transit.
 
 **Mode 3 — Explicit completion (optional)**
@@ -760,7 +760,7 @@ export interface DayConfig {
 
   end: Anchor;
 
-  window: { start: string; end: string }; // "HH:mm"
+  window: { start: string; end: string }; // "HH:mm" (leading zero optional)
 
   mph?: number;
 
@@ -909,7 +909,7 @@ export function slackMin(order: ID\[\], ctx: ScheduleCtx): number
 
 - **Config:** Remove `config.units`. Keep `config.mph` (default **38**).  
 - **Engine:** `haversineMi()` returns miles; `minutesAtMph(distanceMi, mph)` returns minutes. No unit switches or conversions.  
-- **I/O & Output:** Distances reported in miles; durations in minutes; times as `HH:mm`.  
+- **I/O & Output:** Distances reported in miles; durations in minutes; times as `HH:mm` (leading zero optional).
 - **Docs & Examples:** Update JSON examples to drop the `units` field.  
 - **Tests:** Remove metric-specific cases.
 

--- a/docs/rust-belt-store-hours-design.md
+++ b/docs/rust-belt-store-hours-design.md
@@ -13,7 +13,7 @@ This document explores the required input changes, functional requirements, use 
 - **StoreTime‑3:** Do not arrive if the store will close before the required dwell time completes.
 - **StoreTime‑4:** Do not include stores closed on the planned day of week.
 - **StoreTime‑5:** Support multiple open/close windows per day (e.g., 09:00‑12:00 and 13:00‑17:00).
-- **StoreTime‑6:** Treat all times as local to the store and expressed in 24‑hour `HH:MM` format.
+- **StoreTime‑6:** Treat all times as local to the store and expressed in 24‑hour `H:MM` or `HH:MM` format (leading zero optional).
 - **StoreTime‑7:** If a store omits `openHours` entirely, assume it is open all day with no time restrictions.
 
 

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -118,8 +118,8 @@
           "type": "object",
           "required": ["start", "end"],
           "properties": {
-            "start": { "type": "string", "description": "Day start time HH:mm" },
-            "end": { "type": "string", "description": "Day end time HH:mm" }
+            "start": { "type": "string", "description": "Day start time HH:mm (leading zero optional)" },
+            "end": { "type": "string", "description": "Day end time HH:mm (leading zero optional)" }
           }
         },
         "mph": { "type": "number", "description": "Average speed for this day (overrides trip-level mph)" },
@@ -140,8 +140,8 @@
           "type": "object",
           "required": ["start", "end"],
           "properties": {
-            "start": { "type": "string", "description": "Break start time HH:mm" },
-            "end": { "type": "string", "description": "Break end time HH:mm" }
+            "start": { "type": "string", "description": "Break start time HH:mm (leading zero optional)" },
+            "end": { "type": "string", "description": "Break end time HH:mm (leading zero optional)" }
           }
         },
         "robustnessFactor": { "type": "number", "description": "Multiply drive times to add buffer (e.g., 1.1 = +10%)" },

--- a/src/io/parse.ts
+++ b/src/io/parse.ts
@@ -171,7 +171,8 @@ function parseStore(obj: PlainObj): Store {
           );
           }
         const [open, close] = w.map(String);
-        if (!/^\d{2}:\d{2}$/.test(open) || !/^\d{2}:\d{2}$/.test(close)) {
+        // Accept times with or without a leading zero for the hour
+        if (!/^\d{1,2}:\d{2}$/.test(open) || !/^\d{1,2}:\d{2}$/.test(close)) {
           throw new Error(
             `Invalid time format in openHours for store ${id} day ${day}`,
           );

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -22,4 +22,19 @@ describe('parseTrip', () => {
     const { stores } = parseTrip(input);
     expect(stores[0].address).toBe('123 Main St');
   });
+
+  it('accepts single-digit hours in openHours', () => {
+    const input = {
+      stores: [
+        {
+          id: 'a',
+          lat: 0,
+          lon: 0,
+          openHours: { mon: [['9:00', '17:00']] },
+        },
+      ],
+    };
+    const { stores } = parseTrip(input);
+    expect(stores[0].openHours?.mon[0][0]).toBe('9:00');
+  });
 });


### PR DESCRIPTION
## Summary
- accept single-digit hour values like `9:00` in store `openHours`
- document that times may omit a leading zero
- test parsing of single-digit hour strings

## Testing
- `npm test`
- `npm run lint` *(fails: The file was not found in any of the provided project(s))*

------
https://chatgpt.com/codex/tasks/task_e_68c6471f9a64832886a47e10dd7fbdcc