### PR TITLE
feat: support run metadata in trip config

### DIFF
--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -790,6 +790,14 @@ export interface TripConfig {
 
   snapDuplicateToleranceMeters?: number;
 
+  robustnessFactor?: number;
+
+  riskThresholdMin?: number;
+
+  runId?: string;
+
+  runNote?: string;
+
 }
 
 export interface TripInput { config: TripConfig; days: DayConfig\[\]; stores: Store\[\]; }

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -161,7 +161,9 @@
         "seed": { "type": "number", "description": "Random seed for deterministic runs" },
         "snapDuplicateToleranceMeters": { "type": "number", "description": "When set, nearby stores within this distance are treated as duplicates and deduped" },
         "robustnessFactor": { "type": "number", "description": "Global buffer multiplier on drive times (overridden by day/CLI)" },
-        "riskThresholdMin": { "type": "number", "description": "Default slack threshold minutes for risk (overridden by day/CLI)" }
+        "riskThresholdMin": { "type": "number", "description": "Default slack threshold minutes for risk (overridden by day/CLI)" },
+        "runId": { "type": "string", "description": "Identifier for this run" },
+        "runNote": { "type": "string", "description": "Optional note for this run" }
       }
     }
   }

--- a/src/io/parse.ts
+++ b/src/io/parse.ts
@@ -279,6 +279,8 @@ function parseTripConfig(obj?: PlainObj): TripConfig {
     cfg.robustnessFactor = Number(obj.robustnessFactor);
   if (obj.riskThresholdMin !== undefined)
     cfg.riskThresholdMin = Number(obj.riskThresholdMin);
+  if (obj.runId !== undefined) cfg.runId = String(obj.runId);
+  if (obj.runNote !== undefined) cfg.runNote = String(obj.runNote);
   return cfg;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface TripConfig {
   snapDuplicateToleranceMeters?: number;
   robustnessFactor?: number;
   riskThresholdMin?: number;
+  runId?: string;
+  runNote?: string;
 }
 
 export interface Leg {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -37,4 +37,11 @@ describe('parseTrip', () => {
     const { stores } = parseTrip(input);
     expect(stores[0].openHours?.mon[0][0]).toBe('9:00');
   });
+
+  it('parses runId and runNote as strings', () => {
+    const input = { config: { runId: 123, runNote: 456 } };
+    const { config } = parseTrip(input);
+    expect(config.runId).toBe('123');
+    expect(config.runNote).toBe('456');
+  });
 });


### PR DESCRIPTION
## Summary
- allow optional `runId` and `runNote` strings in `TripConfig`
- parse `runId` and `runNote` in trip configuration
- document schema and add tests for new fields

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c7655f20f4832884c08623cf342615