### PR TITLE
Propagate run metadata to emitted itineraries

### DIFF
--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -24,7 +24,7 @@ export function reoptimizeDay(
   opts: ReoptimizeDayOptions,
 ): EmitResult {
   try {
-    const dayPlan = solveCommon({
+    const { dayPlan, runId, note } = solveCommon({
       tripPath: opts.tripPath,
       dayId: opts.dayId,
       startCoord: atCoord,
@@ -42,7 +42,7 @@ export function reoptimizeDay(
     });
 
     const runTimestamp = new Date().toISOString();
-    return emitItinerary([dayPlan], runTimestamp);
+    return emitItinerary([dayPlan], runTimestamp, { runId, note });
   } catch (err) {
     throw augmentErrorWithReasons(err);
   }

--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -44,7 +44,13 @@ export function augmentErrorWithReasons(err: unknown): Error {
   return e;
 }
 
-export function solveCommon(opts: SolveCommonOptions): DayPlan {
+export interface SolveCommonResult {
+  dayPlan: DayPlan;
+  runId?: string;
+  note?: string;
+}
+
+export function solveCommon(opts: SolveCommonOptions): SolveCommonResult {
   const raw = readFileSync(opts.tripPath, 'utf8');
   const json = JSON.parse(raw);
   const trip = parseTrip(json);
@@ -228,6 +234,6 @@ export function solveCommon(opts: SolveCommonOptions): DayPlan {
     },
   };
 
-  return dayPlan;
+  return { dayPlan, runId: trip.config.runId, note: trip.config.runNote };
 }
 

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -23,7 +23,7 @@ export interface SolveDayResult extends EmitResult {
 
 export function solveDay(opts: SolveDayOptions): SolveDayResult {
   try {
-    const dayPlan = solveCommon({
+    const { dayPlan, runId, note } = solveCommon({
       tripPath: opts.tripPath,
       dayId: opts.dayId,
       mph: opts.mph,
@@ -37,7 +37,7 @@ export function solveDay(opts: SolveDayOptions): SolveDayResult {
       riskThresholdMin: opts.riskThresholdMin,
     });
     const runTimestamp = new Date().toISOString();
-    const emit = emitItinerary([dayPlan], runTimestamp);
+    const emit = emitItinerary([dayPlan], runTimestamp, { runId, note });
     return { ...emit, metrics: dayPlan.metrics };
   } catch (err) {
     throw augmentErrorWithReasons(err);

--- a/src/io/emit.ts
+++ b/src/io/emit.ts
@@ -3,11 +3,15 @@ import type { DayPlan } from '../types';
 export interface EmitOptions {
   /** include Markdown summary */
   markdown?: boolean;
+  runId?: string;
+  note?: string;
 }
 
 export interface EmitResult {
   json: string;
   runTimestamp: string;
+  runId?: string;
+  note?: string;
   markdown?: string;
 }
 
@@ -36,8 +40,14 @@ export function emitItinerary(
   runTimestamp = new Date().toISOString(),
   opts: EmitOptions = {},
 ): EmitResult {
-  const json = JSON.stringify({ runTimestamp, days }, null, 2);
+  const json = JSON.stringify(
+    { runTimestamp, runId: opts.runId, note: opts.note, days },
+    null,
+    2,
+  );
   const result: EmitResult = { json, runTimestamp };
+  if (opts.runId) result.runId = opts.runId;
+  if (opts.note) result.note = opts.note;
   if (opts.markdown) {
     result.markdown = toMarkdown(days);
   }
@@ -48,7 +58,9 @@ export { toMarkdown as emitMarkdown };
 export function emitJson(
   days: DayPlan[],
   runTimestamp = new Date().toISOString(),
+  runId?: string,
+  note?: string,
 ): string {
-  return JSON.stringify({ runTimestamp, days }, null, 2);
+  return JSON.stringify({ runTimestamp, runId, note, days }, null, 2);
 }
 

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { solveDay } from '../src/app/solveDay';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { parseTrip } from '../src/io/parse';
 import { computeTimeline } from '../src/schedule';
 import type { Store } from '../src/types';
@@ -21,6 +21,27 @@ describe('solveDay', () => {
     expect(ids).toEqual(['S', 'A', 'B', 'C', 'E']);
     expect(data.days[0].metrics.storesVisited).toBe(3);
     expect(data.days[0].metrics.totalScore).toBe(0);
+  });
+
+  it('includes runId and note when provided', () => {
+    const trip = {
+      config: { mph: 60, defaultDwellMin: 0, seed: 1, runId: 'RID', runNote: 'RN' },
+      days: [
+        {
+          dayId: 'D1',
+          start: { id: 'S', name: 'start', lat: 0, lon: 0 },
+          end: { id: 'E', name: 'end', lat: 0, lon: 0 },
+          window: { start: '00:00', end: '00:10' },
+        },
+      ],
+      stores: [],
+    };
+    const tmpPath = join(__dirname, 'tmp-runid-trip.json');
+    writeFileSync(tmpPath, JSON.stringify(trip));
+    const result = solveDay({ tripPath: tmpPath, dayId: 'D1' });
+    const data = JSON.parse(result.json);
+    expect(data.runId).toBe('RID');
+    expect(data.note).toBe('RN');
   });
 
   it('produces stable itinerary output (FR-31)', () => {


### PR DESCRIPTION
## Summary
- extend solveCommon to return `runId` and `note` from trip config
- forward run metadata through solveDay and reoptimizeDay into emitItinerary
- enhance emitItinerary/EmitResult to include run metadata and test the behavior

## Testing
- `npm test`
- `npm run lint` *(fails: parserOptions.project not found for tests)*
- `npx eslint src --ext .ts`


------
https://chatgpt.com/codex/tasks/task_e_68c77f782f188328a3dda153dfb92b9e