### PR TITLE
docs: add run metadata fields

### DIFF
--- a/docs/rust-belt-output-guide.md
+++ b/docs/rust-belt-output-guide.md
@@ -5,6 +5,8 @@ This page explains how to interpret the JSON produced by `rustbelt solve-day` an
 ```json
 {
   "runTimestamp": "2025-09-11T03:08:45.285Z",
+  "runId": "RID123",
+  "note": "Exploratory run",
   "days": [
     { "dayId": "Clev-Buff", "stops": [...], "metrics": { ... } }
   ]
@@ -14,6 +16,8 @@ This page explains how to interpret the JSON produced by `rustbelt solve-day` an
 ## Top-level fields
 
 - **`runTimestamp`** – The ISO timestamp for when the solver generated the plan. It helps track when the itinerary was last refreshed.
+- **`runId`** – Identifier carried through from the input `TripConfig` for correlating runs.
+- **`note`** – Optional note supplied in the input to label or describe the run.
 - **`days`** – An array of solved days. Each entry contains a `dayId`, an ordered list of `stops`, and a `metrics` summary.
 
 ## Stops

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -796,7 +796,7 @@ export interface TripConfig {
 
   runId?: string;
 
-  runNote?: string;
+  note?: string;
 
 }
 

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -163,7 +163,7 @@
         "robustnessFactor": { "type": "number", "description": "Global buffer multiplier on drive times (overridden by day/CLI)" },
         "riskThresholdMin": { "type": "number", "description": "Default slack threshold minutes for risk (overridden by day/CLI)" },
         "runId": { "type": "string", "description": "Identifier for this run" },
-        "runNote": { "type": "string", "description": "Optional note for this run" }
+        "note": { "type": "string", "description": "Optional note for this run" }
       }
     }
   }


### PR DESCRIPTION
## Summary
- document optional `runId` and `note` fields on TripConfig
- expose `runId` and `note` in interface excerpt
- describe `runId` and `note` in output guide with sample JSON

## Testing
- `npm test`
- `npm run lint` *(fails: parser options project missing for tests)*
- `npx eslint . --ext .ts --ignore-pattern tests`

------
https://chatgpt.com/codex/tasks/task_e_68c7f5d136988328a1fcb84ef8158db6