### PR TITLE
Ensure runId and note fields propagate to output

### DIFF
--- a/fixtures/run-id-note-trip.json
+++ b/fixtures/run-id-note-trip.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "mph": 60,
+    "defaultDwellMin": 0,
+    "seed": 1,
+    "runId": "RID",
+    "note": "RN"
+  },
+  "days": [
+    {
+      "dayId": "D1",
+      "start": { "id": "S", "name": "start", "lat": 0, "lon": 0 },
+      "end": { "id": "E", "name": "end", "lat": 0, "lon": 0 },
+      "window": { "start": "00:00", "end": "00:10" }
+    }
+  ],
+  "stores": []
+}

--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -234,6 +234,6 @@ export function solveCommon(opts: SolveCommonOptions): SolveCommonResult {
     },
   };
 
-  return { dayPlan, runId: trip.config.runId, note: trip.config.runNote };
+  return { dayPlan, runId: trip.config.runId, note: trip.config.note };
 }
 

--- a/src/io/parse.ts
+++ b/src/io/parse.ts
@@ -280,7 +280,8 @@ function parseTripConfig(obj?: PlainObj): TripConfig {
   if (obj.riskThresholdMin !== undefined)
     cfg.riskThresholdMin = Number(obj.riskThresholdMin);
   if (obj.runId !== undefined) cfg.runId = String(obj.runId);
-  if (obj.runNote !== undefined) cfg.runNote = String(obj.runNote);
+  if (obj.note !== undefined) cfg.note = String(obj.note);
+  if (obj.runNote !== undefined) cfg.note = String(obj.runNote);
   return cfg;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export interface TripConfig {
   robustnessFactor?: number;
   riskThresholdMin?: number;
   runId?: string;
-  runNote?: string;
+  note?: string;
 }
 
 export interface Leg {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -38,10 +38,10 @@ describe('parseTrip', () => {
     expect(stores[0].openHours?.mon[0][0]).toBe('9:00');
   });
 
-  it('parses runId and runNote as strings', () => {
-    const input = { config: { runId: 123, runNote: 456 } };
+  it('parses runId and note as strings', () => {
+    const input = { config: { runId: 123, note: 456 } };
     const { config } = parseTrip(input);
     expect(config.runId).toBe('123');
-    expect(config.runNote).toBe('456');
+    expect(config.note).toBe('456');
   });
 });

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { solveDay } from '../src/app/solveDay';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { parseTrip } from '../src/io/parse';
 import { computeTimeline } from '../src/schedule';
 import type { Store } from '../src/types';
@@ -24,21 +24,12 @@ describe('solveDay', () => {
   });
 
   it('includes runId and note when provided', () => {
-    const trip = {
-      config: { mph: 60, defaultDwellMin: 0, seed: 1, runId: 'RID', runNote: 'RN' },
-      days: [
-        {
-          dayId: 'D1',
-          start: { id: 'S', name: 'start', lat: 0, lon: 0 },
-          end: { id: 'E', name: 'end', lat: 0, lon: 0 },
-          window: { start: '00:00', end: '00:10' },
-        },
-      ],
-      stores: [],
-    };
-    const tmpPath = join(__dirname, 'tmp-runid-trip.json');
-    writeFileSync(tmpPath, JSON.stringify(trip));
-    const result = solveDay({ tripPath: tmpPath, dayId: 'D1' });
+    const tripPath = join(__dirname, '../fixtures/run-id-note-trip.json');
+    const raw = readFileSync(tripPath, 'utf8');
+    const trip = parseTrip(JSON.parse(raw));
+    expect(trip.config.runId).toBe('RID');
+    expect(trip.config.note).toBe('RN');
+    const result = solveDay({ tripPath, dayId: 'D1' });
     const data = JSON.parse(result.json);
     expect(data.runId).toBe('RID');
     expect(data.note).toBe('RN');


### PR DESCRIPTION
## Summary
- parse optional `note` alongside `runId` in trip config
- add fixture and test ensuring `solveDay` emits provided `runId` and `note`
- update types and parse tests to reflect `note` field

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c7fd6e0a248328a0cf5ba36111eb4e