### PR TITLE
Use runNote consistently for TripConfig runs

### DIFF
--- a/docs/rust-belt-output-guide.md
+++ b/docs/rust-belt-output-guide.md
@@ -6,7 +6,7 @@ This page explains how to interpret the JSON produced by `rustbelt solve-day` an
 {
   "runTimestamp": "2025-09-11T03:08:45.285Z",
   "runId": "RID123",
-  "note": "Exploratory run",
+  "runNote": "Exploratory run",
   "days": [
     { "dayId": "Clev-Buff", "stops": [...], "metrics": { ... } }
   ]
@@ -17,7 +17,7 @@ This page explains how to interpret the JSON produced by `rustbelt solve-day` an
 
 - **`runTimestamp`** – The ISO timestamp for when the solver generated the plan. It helps track when the itinerary was last refreshed.
 - **`runId`** – Identifier carried through from the input `TripConfig` for correlating runs.
-- **`note`** – Optional note supplied in the input to label or describe the run.
+- **`runNote`** – Optional note supplied in the input to label or describe the run.
 - **`days`** – An array of solved days. Each entry contains a `dayId`, an ordered list of `stops`, and a `metrics` summary.
 
 ## Stops

--- a/docs/rust-belt-route-planner.md
+++ b/docs/rust-belt-route-planner.md
@@ -796,7 +796,7 @@ export interface TripConfig {
 
   runId?: string;
 
-  note?: string;
+  runNote?: string;
 
 }
 

--- a/docs/trip-schema.json
+++ b/docs/trip-schema.json
@@ -163,7 +163,7 @@
         "robustnessFactor": { "type": "number", "description": "Global buffer multiplier on drive times (overridden by day/CLI)" },
         "riskThresholdMin": { "type": "number", "description": "Default slack threshold minutes for risk (overridden by day/CLI)" },
         "runId": { "type": "string", "description": "Identifier for this run" },
-        "note": { "type": "string", "description": "Optional note for this run" }
+        "runNote": { "type": "string", "description": "Optional note for this run" }
       }
     }
   }

--- a/fixtures/run-id-note-trip.json
+++ b/fixtures/run-id-note-trip.json
@@ -4,7 +4,7 @@
     "defaultDwellMin": 0,
     "seed": 1,
     "runId": "RID",
-    "note": "RN"
+    "runNote": "RN"
   },
   "days": [
     {

--- a/src/app/reoptimizeDay.ts
+++ b/src/app/reoptimizeDay.ts
@@ -24,7 +24,7 @@ export function reoptimizeDay(
   opts: ReoptimizeDayOptions,
 ): EmitResult {
   try {
-    const { dayPlan, runId, note } = solveCommon({
+    const { dayPlan, runId, runNote } = solveCommon({
       tripPath: opts.tripPath,
       dayId: opts.dayId,
       startCoord: atCoord,
@@ -42,7 +42,7 @@ export function reoptimizeDay(
     });
 
     const runTimestamp = new Date().toISOString();
-    return emitItinerary([dayPlan], runTimestamp, { runId, note });
+    return emitItinerary([dayPlan], runTimestamp, { runId, runNote });
   } catch (err) {
     throw augmentErrorWithReasons(err);
   }

--- a/src/app/solveCommon.ts
+++ b/src/app/solveCommon.ts
@@ -47,7 +47,7 @@ export function augmentErrorWithReasons(err: unknown): Error {
 export interface SolveCommonResult {
   dayPlan: DayPlan;
   runId?: string;
-  note?: string;
+  runNote?: string;
 }
 
 export function solveCommon(opts: SolveCommonOptions): SolveCommonResult {
@@ -234,6 +234,6 @@ export function solveCommon(opts: SolveCommonOptions): SolveCommonResult {
     },
   };
 
-  return { dayPlan, runId: trip.config.runId, note: trip.config.note };
+  return { dayPlan, runId: trip.config.runId, runNote: trip.config.runNote };
 }
 

--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -23,7 +23,7 @@ export interface SolveDayResult extends EmitResult {
 
 export function solveDay(opts: SolveDayOptions): SolveDayResult {
   try {
-    const { dayPlan, runId, note } = solveCommon({
+    const { dayPlan, runId, runNote } = solveCommon({
       tripPath: opts.tripPath,
       dayId: opts.dayId,
       mph: opts.mph,
@@ -37,7 +37,7 @@ export function solveDay(opts: SolveDayOptions): SolveDayResult {
       riskThresholdMin: opts.riskThresholdMin,
     });
     const runTimestamp = new Date().toISOString();
-    const emit = emitItinerary([dayPlan], runTimestamp, { runId, note });
+    const emit = emitItinerary([dayPlan], runTimestamp, { runId, runNote });
     return { ...emit, metrics: dayPlan.metrics };
   } catch (err) {
     throw augmentErrorWithReasons(err);

--- a/src/io/emit.ts
+++ b/src/io/emit.ts
@@ -4,14 +4,14 @@ export interface EmitOptions {
   /** include Markdown summary */
   markdown?: boolean;
   runId?: string;
-  note?: string;
+  runNote?: string;
 }
 
 export interface EmitResult {
   json: string;
   runTimestamp: string;
   runId?: string;
-  note?: string;
+  runNote?: string;
   markdown?: string;
 }
 
@@ -41,13 +41,13 @@ export function emitItinerary(
   opts: EmitOptions = {},
 ): EmitResult {
   const json = JSON.stringify(
-    { runTimestamp, runId: opts.runId, note: opts.note, days },
+    { runTimestamp, runId: opts.runId, runNote: opts.runNote, days },
     null,
     2,
   );
   const result: EmitResult = { json, runTimestamp };
   if (opts.runId) result.runId = opts.runId;
-  if (opts.note) result.note = opts.note;
+  if (opts.runNote) result.runNote = opts.runNote;
   if (opts.markdown) {
     result.markdown = toMarkdown(days);
   }
@@ -59,8 +59,8 @@ export function emitJson(
   days: DayPlan[],
   runTimestamp = new Date().toISOString(),
   runId?: string,
-  note?: string,
+  runNote?: string,
 ): string {
-  return JSON.stringify({ runTimestamp, runId, note, days }, null, 2);
+  return JSON.stringify({ runTimestamp, runId, runNote, days }, null, 2);
 }
 

--- a/src/io/parse.ts
+++ b/src/io/parse.ts
@@ -280,8 +280,7 @@ function parseTripConfig(obj?: PlainObj): TripConfig {
   if (obj.riskThresholdMin !== undefined)
     cfg.riskThresholdMin = Number(obj.riskThresholdMin);
   if (obj.runId !== undefined) cfg.runId = String(obj.runId);
-  if (obj.note !== undefined) cfg.note = String(obj.note);
-  if (obj.runNote !== undefined) cfg.note = String(obj.runNote);
+  if (obj.runNote !== undefined) cfg.runNote = String(obj.runNote);
   return cfg;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export interface TripConfig {
   robustnessFactor?: number;
   riskThresholdMin?: number;
   runId?: string;
-  note?: string;
+  runNote?: string;
 }
 
 export interface Leg {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -38,10 +38,10 @@ describe('parseTrip', () => {
     expect(stores[0].openHours?.mon[0][0]).toBe('9:00');
   });
 
-  it('parses runId and note as strings', () => {
-    const input = { config: { runId: 123, note: 456 } };
+  it('parses runId and runNote as strings', () => {
+    const input = { config: { runId: 123, runNote: 456 } };
     const { config } = parseTrip(input);
     expect(config.runId).toBe('123');
-    expect(config.note).toBe('456');
+    expect(config.runNote).toBe('456');
   });
 });

--- a/tests/solveDay.test.ts
+++ b/tests/solveDay.test.ts
@@ -23,16 +23,16 @@ describe('solveDay', () => {
     expect(data.days[0].metrics.totalScore).toBe(0);
   });
 
-  it('includes runId and note when provided', () => {
+  it('includes runId and runNote when provided', () => {
     const tripPath = join(__dirname, '../fixtures/run-id-note-trip.json');
     const raw = readFileSync(tripPath, 'utf8');
     const trip = parseTrip(JSON.parse(raw));
     expect(trip.config.runId).toBe('RID');
-    expect(trip.config.note).toBe('RN');
+    expect(trip.config.runNote).toBe('RN');
     const result = solveDay({ tripPath, dayId: 'D1' });
     const data = JSON.parse(result.json);
     expect(data.runId).toBe('RID');
-    expect(data.note).toBe('RN');
+    expect(data.runNote).toBe('RN');
   });
 
   it('produces stable itinerary output (FR-31)', () => {


### PR DESCRIPTION
## Summary
- rename TripConfig's `note` field to `runNote`
- update parsing, emitting, and CLI code to use `runNote`
- document the `runNote` field in schema and output guide

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.)*

------
https://chatgpt.com/codex/tasks/task_e_68c8023ea44c83288fe66d5c7839fe36