### PR TITLE
feat: display run ID and note in HTML itinerary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,15 +31,11 @@ program
   .showHelpAfterError();
 
 program
-  .command('solve-day',  { isDefault: true })
+  .command('solve-day', { isDefault: true })
   .requiredOption('--trip <file>', 'Path to trip JSON file')
   .requiredOption('--day <id>', 'Day id to solve')
   .option('--mph <mph>', 'Average speed in mph', parseFloat)
-  .option(
-    '--default-dwell <min>',
-    'Default dwell minutes',
-    parseFloat,
-  )
+  .option('--default-dwell <min>', 'Default dwell minutes', parseFloat)
   .option('--seed <seed>', 'Random seed', parseFloat)
   .option('--lambda <lambda>', 'Score weighting (0=count,1=score)', parseFloat)
   .option('--verbose', 'Print heuristic steps')
@@ -71,25 +67,21 @@ program
             .map((s) => s.trim())
             .filter(Boolean)
         : undefined;
-      result = reoptimizeDay(
-        opts.now,
-        [lat, lon],
-        {
-          tripPath: opts.trip,
-          dayId: opts.day,
-          mph: opts.mph,
-          defaultDwellMin: opts.defaultDwell,
-          seed: opts.seed,
-          lambda: opts.lambda,
-          verbose: opts.verbose,
-          completedIds,
-          progress: opts.progress
-            ? buildProgressLogger(Boolean(opts.verbose))
-            : undefined,
-          robustnessFactor: opts.robustness,
-          riskThresholdMin: opts['risk-threshold'],
-        },
-      );
+      result = reoptimizeDay(opts.now, [lat, lon], {
+        tripPath: opts.trip,
+        dayId: opts.day,
+        mph: opts.mph,
+        defaultDwellMin: opts.defaultDwell,
+        seed: opts.seed,
+        lambda: opts.lambda,
+        verbose: opts.verbose,
+        completedIds,
+        progress: opts.progress
+          ? buildProgressLogger(Boolean(opts.verbose))
+          : undefined,
+        robustnessFactor: opts.robustness,
+        riskThresholdMin: opts['risk-threshold'],
+      });
     } else {
       result = solveDay({
         tripPath: opts.trip,
@@ -113,10 +105,11 @@ program
     };
     const runTs = result.runTimestamp;
     const runId = result.runId;
+    const runNote = result.runNote;
     const tsToken = formatTimestampToken(runTs);
     const tokenize = (s: string): string =>
       s.replace(/\$\{(runId|timestamp)\}/g, (_, k) =>
-        k === 'runId' ? runId ?? '' : tsToken,
+        k === 'runId' ? (runId ?? '') : tsToken,
       );
 
     if (opts.out) {
@@ -163,7 +156,7 @@ program
     }
 
     if (opts.html !== undefined) {
-      const html = emitHtml(data.days, runTs);
+      const html = emitHtml(data.days, runTs, { runId, runNote });
       if (typeof opts.html === 'string') {
         const htmlPath = tokenize(opts.html);
         mkdirSync(dirname(htmlPath), { recursive: true });
@@ -176,7 +169,7 @@ program
 
     console.log(result.json);
   });
-  
+
 export function run(argv: readonly string[] = process.argv): Command {
   program.parse(argv as string[]);
   return program;

--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -7,7 +7,10 @@ const defaultTemplate = readFileSync(
   'utf8',
 );
 const defaultPartials = {
-  stop: readFileSync(new URL('./templates/stop.mustache', import.meta.url), 'utf8'),
+  stop: readFileSync(
+    new URL('./templates/stop.mustache', import.meta.url),
+    'utf8',
+  ),
 };
 
 export interface EmitHtmlOptions {
@@ -15,9 +18,15 @@ export interface EmitHtmlOptions {
   template?: string;
   /** Override or add partials */
   partials?: Record<string, string>;
+  /** Optional run identifier */
+  runId?: string;
+  /** Optional run note */
+  runNote?: string;
 }
 
 interface ViewModel {
+  runId?: string;
+  runNote?: string;
   days: {
     dayId: string;
     stops: {
@@ -38,6 +47,8 @@ export function emitHtml(
 ): string {
   const view: ViewModel & { runTimestamp: string } = {
     runTimestamp,
+    runId: opts.runId,
+    runNote: opts.runNote,
     days: days.map((d) => ({
       dayId: d.dayId,
       stops: d.stops.map((s) => ({

--- a/src/io/templates/itinerary.mustache
+++ b/src/io/templates/itinerary.mustache
@@ -4,6 +4,12 @@
     <title>Itinerary</title>
   </head>
   <body>
+    {{#runId}}
+    <p>Run ID: {{runId}}</p>
+    {{/runId}}
+    {{#runNote}}
+    <p>Run note: {{runNote}}</p>
+    {{/runNote}}
     <p>Run timestamp: {{runTimestamp}}</p>
     {{#days}}
     <h2>Day {{dayId}}</h2>

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -7,7 +7,15 @@ describe('emitHtml', () => {
     const day: DayPlan = {
       dayId: 'D1',
       stops: [
-        { id: 'S', name: 'Start', type: 'start', arrive: '09:00', depart: '09:00', lat: 0, lon: 0 },
+        {
+          id: 'S',
+          name: 'Start',
+          type: 'start',
+          arrive: '09:00',
+          depart: '09:00',
+          lat: 0,
+          lon: 0,
+        },
         {
           id: 'A',
           name: 'Store A',
@@ -18,7 +26,15 @@ describe('emitHtml', () => {
           lon: 2,
           score: 1,
         },
-        { id: 'E', name: 'End', type: 'end', arrive: '09:30', depart: '09:30', lat: 3, lon: 4 },
+        {
+          id: 'E',
+          name: 'End',
+          type: 'end',
+          arrive: '09:30',
+          depart: '09:30',
+          lat: 3,
+          lon: 4,
+        },
       ],
       metrics: {
         storeCount: 1,
@@ -37,10 +53,14 @@ describe('emitHtml', () => {
       },
     };
     const runTs = '2024-01-01T00:00:00Z';
-    const html = emitHtml([day], runTs);
+    const runId = 'test-id';
+    const runNote = 'test note';
+    const html = emitHtml([day], runTs, { runId, runNote });
     expect(html).toContain('<h2>Day D1</h2>');
     expect(html).toContain('Store A');
     expect(html).toContain(runTs);
+    expect(html).toContain(runId);
+    expect(html).toContain(runNote);
     // one row per stop inside tbody
     const tbody = html.split('<tbody>')[1].split('</tbody>')[0];
     const rows = tbody.match(/<tr>/g) || [];


### PR DESCRIPTION
## Summary
- show run ID and run note in the default HTML itinerary template
- plumb run context through `emitHtml` and CLI call
- test HTML output for run context

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: The file was not found in any of the provided project(s): tests/reoptimizeDay.test.ts, tests/schedule.test.ts, tests/solveDay.test.ts, tests/store-hours.test.ts, tests/synthetic-day.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c814dd2ba08328881ed5583db62638