### PR TITLE
Add getting started guide and sample trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Utility for planning store visits.
 
 ## Getting Started
 
+Refer to the [Getting Started guide](docs/getting-started.md) for a full walkthrough, including validation tips powered by the [trip schema](docs/trip-schema.json).
+
 1. **Install dependencies**
    ```sh
    npm install
@@ -13,13 +15,40 @@ Utility for planning store visits.
    npm run build
    ```
    This compiles TypeScript sources to `dist/`.
-3. **Run a solve**
+3. **Create a trip file**
+   Save the following minimal example as `fixtures/getting-started-trip.json`:
+   ```json
+   {
+     "config": {
+       "mph": 30,
+       "defaultDwellMin": 15
+     },
+     "days": [
+       {
+         "dayId": "day-1",
+         "start": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+         "end": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+         "window": { "start": "8:00", "end": "17:00" }
+       }
+     ],
+     "stores": [
+       {
+         "id": "store-1",
+         "name": "Coffee Stop",
+         "lat": 41.6,
+         "lon": -81.69,
+         "dwellMin": 15
+       }
+     ]
+   }
+   ```
+4. **Run a solve**
    ```sh
-   npx tsx src/index.ts solve-day --trip trips/example.json --day 2025-10-01
+   npx tsx src/index.ts solve-day --trip fixtures/getting-started-trip.json --day day-1
    ```
    After building you can also run:
    ```sh
-   node dist/index.js solve-day --trip trips/example.json --day 2025-10-01
+   node dist/index.js solve-day --trip fixtures/getting-started-trip.json --day day-1
    ```
 
 ## Documentation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,73 @@
+# Getting Started
+
+This guide walks through setting up the Rust Belt CLI, authoring an input trip, and running your first solve.
+
+## 1. Install dependencies
+
+Use npm to install the workspace dependencies:
+
+```sh
+npm install
+```
+
+## 2. Build the CLI
+
+Compile the TypeScript sources before running the CLI directly:
+
+```sh
+npm run build
+```
+
+The build output is emitted to `dist/`, which can be executed with Node or packaged for distribution.
+
+## 3. Create a minimal trip file
+
+Every trip includes three root properties: `config`, `days`, and `stores`. The snippet below highlights the required fields and is saved as `fixtures/getting-started-trip.json` for convenience:
+
+```json
+{
+  "config": {
+    "mph": 30,
+    "defaultDwellMin": 15
+  },
+  "days": [
+    {
+      "dayId": "day-1",
+      "start": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+      "end": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+      "window": { "start": "8:00", "end": "17:00" }
+    }
+  ],
+  "stores": [
+    {
+      "id": "store-1",
+      "name": "Coffee Stop",
+      "lat": 41.6,
+      "lon": -81.69,
+      "dwellMin": 15
+    }
+  ]
+}
+```
+
+Refer to the [trip schema](trip-schema.json) for a full description of every supported field and validation constraints.
+
+## 4. Validate the trip
+
+Use your preferred JSON Schema validator with [`docs/trip-schema.json`](trip-schema.json) to catch missing or malformed fields. For example, `ajv` can be run with `npx ajv validate -s docs/trip-schema.json -d fixtures/getting-started-trip.json`.
+
+## 5. Run a solve
+
+Execute the CLI with the `solve-day` command, passing the day identifier from your trip file:
+
+```sh
+npx tsx src/index.ts solve-day --trip fixtures/getting-started-trip.json --day day-1
+```
+
+After building, you can also invoke the compiled bundle:
+
+```sh
+node dist/index.js solve-day --trip fixtures/getting-started-trip.json --day day-1
+```
+
+This produces an itinerary JSON payload on stdout that you can redirect to a file or pipe into another tool.

--- a/fixtures/getting-started-trip.json
+++ b/fixtures/getting-started-trip.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "mph": 30,
+    "defaultDwellMin": 15
+  },
+  "days": [
+    {
+      "dayId": "day-1",
+      "start": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+      "end": { "id": "hotel", "lat": 41.5, "lon": -81.7 },
+      "window": { "start": "8:00", "end": "17:00" }
+    }
+  ],
+  "stores": [
+    {
+      "id": "store-1",
+      "name": "Coffee Stop",
+      "lat": 41.6,
+      "lon": -81.69,
+      "dwellMin": 15
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated getting started guide that links to the trip schema and outlines validation steps
- update the README getting started section with a minimal trip example and matching run command
- check in the sample trip JSON used in the guide and README instructions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c856714dac8328b2de84bb2f593f6e