### PR TITLE
Add quick start instructions to CLI docs

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -2,6 +2,17 @@
 
 This document describes how to use the `rustbelt` command-line interface. The solver honors per‑store open hours so that closed locations are never scheduled.
 
+## Quick Start
+
+1. Review the minimal trip JSON in the [Getting Started guide](getting-started.md); the sample is saved at `fixtures/getting-started-trip.json`.
+2. Solve the demo day with:
+
+   ```sh
+   rustbelt solve-day --trip fixtures/getting-started-trip.json --day day-1
+   ```
+
+   The itinerary JSON prints to stdout; pass `--out <file>` if you also want to save it to disk.
+
 ## Setup
 
 Install dependencies and run the CLI either directly from the TypeScript


### PR DESCRIPTION
## Summary
- add a Quick Start section to the CLI documentation
- point to the Getting Started sample trip and show the demo day command with output location

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c85873e1e88328ac989c203b0d31ab