### PR TITLE
Split route planner documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Refer to the [Getting Started guide](docs/getting-started.md) for a full walkthr
 - [CLI usage](docs/rust-belt-cli-documentation.md)
 - [Trip schema](docs/trip-schema.json)
 - [Test plan](docs/rust-belt-test-plan.md)
-- [Route planner roadmap](docs/rust-belt-route-planner.md)
+- [Route planner overview](docs/route-planner-overview.md)
+- [Route planner implementation notes](docs/route-planner-implementation.md)
 
 ## Output Options
 

--- a/docs/route-planner-implementation.md
+++ b/docs/route-planner-implementation.md
@@ -1,13 +1,8 @@
-# Project: Multi-Day Thrift Route Planner (OPTW-lite)
+# Route Planner Implementation Notes
 
 See [CLI usage](rust-belt-cli-documentation.md) for command details and the
-[trip schema](trip-schema.json) for input structure.
-
-## Problem Frame & Goals
-
-- **Goal:** Build a planner that **maximizes number of stores visited per day** on a multi-day Detroit → Cleveland (overnight) → Buffalo (overnight) trip, with fixed daily start/end anchors and simple travel modeling.  
-- **Model:** A practical variant of the **Orienteering Problem** that respects store open hours. Per day: choose and order stops to maximize count under a daily time budget (drive \+ dwell) using **Haversine distance × constant mph**.
-- **Key non-goal:** Shortest route. Efficiency is in service of **more stores while still reaching the hotel on time**.
+[trip schema](trip-schema.json) for input structure. For high-level goals and
+milestone context, refer to the [Route planner overview](route-planner-overview.md).
 
 # Features at a Glance 
 

--- a/docs/route-planner-overview.md
+++ b/docs/route-planner-overview.md
@@ -1,0 +1,52 @@
+# Project: Multi-Day Thrift Route Planner (OPTW-lite)
+
+See [CLI usage](rust-belt-cli-documentation.md) for command details and the
+[trip schema](trip-schema.json) for input structure. Detailed requirements and
+implementation guidance live in the [Route planner implementation
+notes](route-planner-implementation.md).
+
+## Problem Frame & Goals
+
+- **Goal:** Build a planner that **maximizes number of stores visited per day** on
+  a multi-day Detroit → Cleveland (overnight) → Buffalo (overnight) trip, with
+  fixed daily start/end anchors and simple travel modeling.
+- **Model:** A practical variant of the **Orienteering Problem** that respects
+  store open hours. Per day: choose and order stops to maximize count under a
+  daily time budget (drive + dwell) using **Haversine distance × constant mph**.
+- **Key non-goal:** Shortest route. Efficiency is in service of **more stores
+  while still reaching the hotel on time**.
+
+## Milestone Roadmap
+
+### v0.1 — Core Day-By-Day Planner (MVP) — Implemented
+
+- Deterministic heuristic solver that segments trips into days, honors
+  must-visit stores, and maximizes visit count under a daily time budget.
+- Generates per-day itineraries with arrival/departure times, dwell, drive,
+  slack, and summary metrics.
+
+### v0.2 — Usability & Resilience — In progress
+
+- Add tools for locking/pinning stops, re-optimizing mid-day, and reporting
+  minimal relaxations when plans become infeasible.
+- Surface richer diagnostics, including best-so-far progress updates.
+
+### v0.3 — Power Controls & Robustness — Planned
+
+- Introduce score-based objectives, daily caps, break windows, and optional
+  spatial filters (corridor/polygon) to guide stop selection.
+- Provide robustness controls that inflate travel time and expose **On-Time
+  Risk** indicators.
+
+### v0.4 — Explainability & Scenarios (Stretch) — Planned
+
+- Save and compare scenarios while tracking differences in stops and key
+  metrics.
+- Explain why stores were excluded and highlight nearest alternatives.
+
+## Out of Scope / De-scoped (for now)
+
+- **FR-15** Spatial filter: corridor/polygon
+- **FR-19** Turn-by-turn export / deep links
+- **FR-23** Special cluster handling (keep exact-coordinate dedupe only)
+- **FR-26**, **FR-27** Presets (nice-to-have future)


### PR DESCRIPTION
## Summary
- add a route planner overview that captures goals and milestone framing
- move the detailed feature lists and implementation notes into their own document
- update documentation links to reference the new files

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c8673be3bc83288792fb7d0fb3fb9c