### PR TITLE
Surface constraint notes in solver outputs

### DIFF
--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -21,6 +21,10 @@ export interface SolveDayResult extends EmitResult {
   metrics: DayPlan['metrics'];
 }
 
+function formatConstraintList(values?: readonly string[]): string {
+  return values && values.length ? values.join(', ') : 'none';
+}
+
 export function solveDay(opts: SolveDayOptions): SolveDayResult {
   try {
     const { dayPlan, runId, runNote } = solveCommon({
@@ -38,6 +42,18 @@ export function solveDay(opts: SolveDayOptions): SolveDayResult {
     });
     const runTimestamp = new Date().toISOString();
     const emit = emitItinerary([dayPlan], runTimestamp, { runId, runNote });
+    const m = dayPlan.metrics;
+    const summaryParts = [
+      `Day ${dayPlan.dayId}`,
+      `stores=${m.storesVisited}`,
+      `score=${m.totalScore.toFixed(1)}`,
+      `drive=${m.totalDriveMin.toFixed(1)} min`,
+      `dwell=${m.totalDwellMin.toFixed(1)} min`,
+      `slack=${m.slackMin.toFixed(1)} min`,
+      `binding=${formatConstraintList(m.bindingConstraints)}`,
+      `violations=${formatConstraintList(m.limitViolations)}`,
+    ];
+    console.log(summaryParts.join(' | '));
     return { ...emit, metrics: dayPlan.metrics };
   } catch (err) {
     throw augmentErrorWithReasons(err);

--- a/src/io/emit.ts
+++ b/src/io/emit.ts
@@ -31,6 +31,20 @@ function toMarkdown(days: DayPlan[]): string {
     );
   }
   lines.push('');
+
+  const formatList = (values?: readonly string[]): string =>
+    values && values.length ? values.map((v) => `\`${v}\``).join(', ') : '_None_';
+
+  lines.push('## Constraint Notes', '');
+  for (const d of days) {
+    const m = d.metrics;
+    lines.push(
+      `- **${d.dayId}** – Binding: ${formatList(m.bindingConstraints)}; Violations: ${formatList(
+        m.limitViolations,
+      )}`,
+    );
+  }
+  lines.push('');
   return lines.join('\n');
 }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,8 +63,10 @@ describe('CLI', () => {
       'D1',
     ]);
 
-    expect(log).toHaveBeenCalledTimes(1);
-    expect(() => JSON.parse(log.mock.calls[0][0])).not.toThrow();
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(String(log.mock.calls[0][0])).toContain('binding=');
+    expect(String(log.mock.calls[0][0])).toContain('violations=');
+    expect(() => JSON.parse(log.mock.calls[1][0])).not.toThrow();
     log.mockRestore();
   });
 
@@ -85,9 +87,11 @@ describe('CLI', () => {
       '--html',
     ]);
 
-    expect(log).toHaveBeenCalledTimes(2);
-    expect(String(log.mock.calls[0][0])).toContain('<html>');
-    expect(() => JSON.parse(log.mock.calls[1][0])).not.toThrow();
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(String(log.mock.calls[0][0])).toContain('binding=');
+    expect(String(log.mock.calls[0][0])).toContain('violations=');
+    expect(String(log.mock.calls[1][0])).toContain('<html>');
+    expect(() => JSON.parse(log.mock.calls[2][0])).not.toThrow();
     log.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- log a richer day summary from solveDay that reports binding constraints and limit violations
- extend the Markdown emission with a per-day constraint notes section
- update CLI tests to reflect the additional console summary line

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87c192d548328af28a6e16004f814