### PR TITLE
Document constraint diagnostics in output guide

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -125,6 +125,8 @@ the `<ExtendedData>` entries.
 
 The solver prints the resulting itinerary as JSON, including a `runTimestamp` field for tracking when the plan was generated. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided. Using `--csv` saves a CSV of all store stops. Passing `--html` writes an HTML itinerary to the given file or stdout; templates can be customized via `emitHtml`.
 
+After emitting the JSON, the CLI prints a one-line summary that includes any binding or violated limits (e.g., `binding=maxStops | violations=none`). See the [constraint diagnostics](rust-belt-output-guide.md#constraint-diagnostics) section of the output guide for definitions and examples of these diagnostics.
+
 ## Examples
 
 Solve a day and save the itinerary and store stops:

--- a/docs/rust-belt-output-guide.md
+++ b/docs/rust-belt-output-guide.md
@@ -77,7 +77,9 @@ The `metrics` block summarizes the solved day:
   "totalDwellMin": 210,
   "slackMin": 4.40,
   "totalDistanceMiles": 310.5,
-  "onTimeRisk": 0.125
+  "onTimeRisk": 0.125,
+  "limitViolations": ["maxDriveTime"],
+  "bindingConstraints": ["maxStops"]
 }
 ```
 
@@ -96,6 +98,8 @@ The `metrics` block summarizes the solved day:
 | [`slackMin`](#metric-slackmin) | Unused buffer minutes left in the schedule. |
 | [`totalDistanceMiles`](#metric-totaldistancemiles) | Miles driven between itinerary stops. |
 | [`onTimeRisk`](#metric-ontimerisk) | Share of legs that fall below the slack threshold. |
+| [`limitViolations`](#metric-limitviolations) | Constraints exceeded by the final itinerary. |
+| [`bindingConstraints`](#metric-bindingconstraints) | Constraints that were exactly satisfied (tight). |
 
 - <a id="metric-storecount"></a>**`storeCount`** – Total number of candidate stores considered for the day.
 - <a id="metric-storesvisited"></a>**`storesVisited`** – Number of store stops completed.
@@ -110,6 +114,8 @@ The `metrics` block summarizes the solved day:
 - <a id="metric-slackmin"></a>**`slackMin`** – Unused minutes in the schedule. Low slack means the day is tightly packed.
 - <a id="metric-totaldistancemiles"></a>**`totalDistanceMiles`** – Total miles driven between stops.
 - <a id="metric-ontimerisk"></a>**`onTimeRisk`** – Fraction of legs with slack below the configured risk threshold. A higher value indicates more chance of falling behind schedule.
+- <a id="metric-limitviolations"></a>**`limitViolations`** – Optional array naming constraints the solver could not satisfy. Values match the configuration knobs (e.g., `maxDriveTime`).
+- <a id="metric-bindingconstraints"></a>**`bindingConstraints`** – Optional array naming constraints that were exactly tight. These highlight limits that shaped the itinerary even though they were not exceeded.
 
 Use these numbers to gauge itinerary efficiency and feasibility. For example, a high `totalDriveMin` with low `storesVisited` may suggest the stores are too far apart, while minimal `slackMin` combined with `onTimeRisk` above `0` signals a schedule that may be hard to keep.
 
@@ -152,3 +158,52 @@ In the example itinerary above, there are eight legs. With a threshold of `15` m
 - **Higher threshold, more conservative plan:** Using the same slack values but raising the threshold to `30`, both the second and third legs fall short, yielding `onTimeRisk = 2/3 ≈ 0.67`. The higher threshold forces you to treat more of the day as tight.
 
 Tactically, a high `onTimeRisk` means delays on multiple legs could push you past the day's end. Lower it by dropping distant stores, adding slack (e.g., a later end time), or increasing drive time estimates with `--robustness` or lower `--mph`.
+
+## Constraint diagnostics
+
+The solver reports whether hard limits influenced or blocked the itinerary through two optional arrays inside `metrics`:
+
+- **`limitViolations`** – Lists constraints the plan exceeded.
+- **`bindingConstraints`** – Lists constraints that finished exactly at their cap.
+
+When neither list has entries, the fields are omitted from the JSON, and the CLI summary prints `violations=none` and `binding=none`.
+
+### Example: Hitting a stop cap
+
+If a day enforces `maxStops: 7` and the solver visits seven stores, the limit becomes binding:
+
+```json
+{
+  "metrics": {
+    "storesVisited": 7,
+    "bindingConstraints": ["maxStops"]
+  }
+}
+```
+
+Because the cap was met exactly, no violation occurs, but `bindingConstraints` reveals that adding another store would require raising `maxStops`. The CLI prints a summary line similar to:
+
+```
+Day RustBelt-1 | stores=7 | … | binding=maxStops | violations=none
+```
+
+Notice that `limitViolations` is absent from the JSON because there were no overruns, mirroring the `violations=none` text in the CLI summary.
+
+### Example: Drive time violation
+
+If the itinerary's total driving time passes a configured maximum, it appears under `limitViolations`:
+
+```json
+{
+  "metrics": {
+    "totalDriveMin": 330.5,
+    "limitViolations": ["maxDriveTime"]
+  }
+}
+```
+
+In this scenario the solver could not produce a plan within the allowed drive time. The CLI summary shows `violations=maxDriveTime`, making it easy to spot the overage and adjust inputs (reduce the store list, extend the window, or lift the limit).
+
+Here `bindingConstraints` is omitted because no limit finished exactly on its boundary.
+
+Both arrays currently surface `maxStops` and `maxDriveTime`, matching the supported limits. Future constraints will appear in the same lists without requiring output changes.


### PR DESCRIPTION
## Summary
- expand the output guide with limitViolations and bindingConstraints definitions, table entries, and JSON examples
- document how the CLI summary exposes binding/violation diagnostics and link to the detailed explanations
- clarify when the diagnostics arrays are omitted so users can match JSON and CLI output

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c88b699f04832885f39cd67c372d99