### PR TITLE
Document break window CLI example

### DIFF
--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -141,6 +141,30 @@ Reoptimize from 1:30 PM at a specific location:
 rustbelt solve-day --trip trips/example.json --day 2025-10-01 --now 13:30 --at 41.5,-81.7
 ```
 
+### Reserve a midday break
+
+The solver can schedule downtime inside a target window. Passing
+`--break-window 12:00-13:00` inserts a special stop with the `BREAK_ID`
+(`__break__`) during that hour:
+
+```
+rustbelt solve-day --trip trips/example.json --day 2025-10-01 --break-window 12:00-13:00
+```
+
+The resulting itinerary JSON includes a `type: "break"` entry that
+highlights when the pause occurs:
+
+```json
+{
+  "id": "__break__",
+  "name": "Break",
+  "type": "break",
+  "arrive": "12:15",
+  "depart": "12:45",
+  "dwellMin": 30
+}
+```
+
 ## See also
 
 - [Trip schema](trip-schema.json) – structure of trip JSON files

--- a/docs/rust-belt-output-guide.md
+++ b/docs/rust-belt-output-guide.md
@@ -59,6 +59,23 @@ The solver expects a 38‑minute drive from the start location to the store and 
 
 This later stop arrives at 17:11 after a 56‑minute drive. The high `score` of 4.8 and `Thrift` tag indicate a priority thrift store. Comparing stops helps identify where long drives occur or which stores contribute most to the total score.
 
+### Example: Break stop (`BREAK_ID`)
+
+When a break window is requested, the itinerary includes a pseudo-stop with
+the special ID `__break__`. The entry records the local arrival and departure
+times just like a store, making it clear when the downtime occurs:
+
+```json
+{
+  "id": "__break__",
+  "name": "Break",
+  "type": "break",
+  "arrive": "12:15",
+  "depart": "12:45",
+  "dwellMin": 30
+}
+```
+
 ## Metrics
 
 The `metrics` block summarizes the solved day:


### PR DESCRIPTION
## Summary
- add an examples subsection showing how to call the CLI with --break-window
- illustrate the resulting BREAK_ID stop emitted in the itinerary output
- extend the output guide with a JSON snippet for the break stop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8ac1ae2688328a23e00b651fda68c