### PR TITLE
Track excluded store reasons and alternatives

### DIFF
--- a/src/app/solveDay.ts
+++ b/src/app/solveDay.ts
@@ -54,6 +54,18 @@ export function solveDay(opts: SolveDayOptions): SolveDayResult {
       `violations=${formatConstraintList(m.limitViolations)}`,
     ];
     console.log(summaryParts.join(' | '));
+    if (dayPlan.excluded.length > 0) {
+      const details = dayPlan.excluded
+        .map((e) =>
+          `${e.id} (${e.reason}${
+            e.nearestAlternateId ? ` → ${e.nearestAlternateId}` : ''
+          })`,
+        )
+        .join('; ');
+      console.log(`  Excluded: ${details}`);
+    } else {
+      console.log('  Excluded: none');
+    }
     return { ...emit, metrics: dayPlan.metrics };
   } catch (err) {
     throw augmentErrorWithReasons(err);

--- a/src/io/emit.ts
+++ b/src/io/emit.ts
@@ -35,6 +35,17 @@ function toMarkdown(days: DayPlan[]): string {
   const formatList = (values?: readonly string[]): string =>
     values && values.length ? values.map((v) => `\`${v}\``).join(', ') : '_None_';
 
+  const formatExcluded = (values: DayPlan['excluded']): string =>
+    values.length
+      ? values
+          .map((e) =>
+            `\`${e.id}\` (${e.reason}${
+              e.nearestAlternateId ? ` → \`${e.nearestAlternateId}\`` : ''
+            })`,
+          )
+          .join(', ')
+      : '_None_';
+
   lines.push('## Constraint Notes', '');
   for (const d of days) {
     const m = d.metrics;
@@ -43,6 +54,12 @@ function toMarkdown(days: DayPlan[]): string {
         m.limitViolations,
       )}`,
     );
+  }
+  lines.push('');
+
+  lines.push('## Exclusions', '');
+  for (const d of days) {
+    lines.push(`- **${d.dayId}** – ${formatExcluded(d.excluded)}`);
   }
   lines.push('');
   return lines.join('\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,9 +88,16 @@ export interface StopPlan {
   tags?: string[];
 }
 
+export interface ExcludedStorePlan {
+  id: ID;
+  reason: string;
+  nearestAlternateId?: ID;
+}
+
 export interface DayPlan {
   dayId: string;
   stops: StopPlan[];
+  excluded: ExcludedStorePlan[];
   metrics: {
     storeCount: number;
     storesVisited: number;

--- a/tests/__snapshots__/solveDay.test.ts.snap
+++ b/tests/__snapshots__/solveDay.test.ts.snap
@@ -5,6 +5,7 @@ exports[`solveDay > produces stable itinerary output (FR-31) 1`] = `
   "days": [
     {
       "dayId": "D1",
+      "excluded": [],
       "metrics": {
         "onTimeRisk": 0,
         "scorePerDriveMin": 0,
@@ -108,6 +109,18 @@ exports[`solveDay > reports constraint metadata when caps are binding 1`] = `
   "days": [
     {
       "dayId": "D1",
+      "excluded": [
+        {
+          "id": "A",
+          "nearestAlternateId": "B",
+          "reason": "maxStops",
+        },
+        {
+          "id": "C",
+          "nearestAlternateId": "B",
+          "reason": "maxStops",
+        },
+      ],
       "metrics": {
         "bindingConstraints": [
           "maxDriveTime",

--- a/tests/emitCsv.test.ts
+++ b/tests/emitCsv.test.ts
@@ -6,11 +6,11 @@ describe('emitCsv', () => {
   it('includes run timestamp and must_visit metadata', () => {
     const day: DayPlan = {
       dayId: 'D1',
-        stops: [
-          { id: 'S', name: 'Start', type: 'start', arrive: '09:00', depart: '09:00', lat: 0, lon: 0 },
-          {
-            id: 'A',
-            name: 'Store A',
+      stops: [
+        { id: 'S', name: 'Start', type: 'start', arrive: '09:00', depart: '09:00', lat: 0, lon: 0 },
+        {
+          id: 'A',
+          name: 'Store A',
             type: 'store',
             arrive: '09:10',
             depart: '09:20',
@@ -43,6 +43,7 @@ describe('emitCsv', () => {
           legIn: { fromId: 'B', toId: 'E', driveMin: 10, distanceMi: 5 },
         },
       ],
+      excluded: [],
       metrics: {
         storeCount: 2,
         storesVisited: 2,

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -36,6 +36,7 @@ describe('emitHtml', () => {
           lon: 4,
         },
       ],
+      excluded: [],
       metrics: {
         storeCount: 1,
         storesVisited: 1,

--- a/tests/emitKml.test.ts
+++ b/tests/emitKml.test.ts
@@ -70,6 +70,7 @@ describe('emitKml', () => {
             lon: 2,
           },
         ],
+        excluded: [],
         metrics: {
           storeCount: 1,
           storesVisited: 1,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,10 +63,11 @@ describe('CLI', () => {
       'D1',
     ]);
 
-    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledTimes(3);
     expect(String(log.mock.calls[0][0])).toContain('binding=');
     expect(String(log.mock.calls[0][0])).toContain('violations=');
-    expect(() => JSON.parse(log.mock.calls[1][0])).not.toThrow();
+    expect(String(log.mock.calls[1][0])).toContain('Excluded:');
+    expect(() => JSON.parse(log.mock.calls[2][0])).not.toThrow();
     log.mockRestore();
   });
 
@@ -87,11 +88,12 @@ describe('CLI', () => {
       '--html',
     ]);
 
-    expect(log).toHaveBeenCalledTimes(3);
+    expect(log).toHaveBeenCalledTimes(4);
     expect(String(log.mock.calls[0][0])).toContain('binding=');
     expect(String(log.mock.calls[0][0])).toContain('violations=');
-    expect(String(log.mock.calls[1][0])).toContain('<html>');
-    expect(() => JSON.parse(log.mock.calls[2][0])).not.toThrow();
+    expect(String(log.mock.calls[1][0])).toContain('Excluded:');
+    expect(String(log.mock.calls[2][0])).toContain('<html>');
+    expect(() => JSON.parse(log.mock.calls[3][0])).not.toThrow();
     log.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- capture feasibility reasons for stores left out of a plan and compute nearest visited alternates
- extend the day plan model and outputs to include exclusion diagnostics in CLI and markdown summaries
- add regression coverage ensuring exclusion reasons are reported with reachable alternatives

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8bd767a5083288872716774ee56f0