### PR TITLE
Format timestamp tokens in local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ be generated with flags:
 
 Output paths may include `${runId}` and `${timestamp}` tokens. These expand to
 the trip's `runId` (if provided) and the solver run timestamp formatted as
-`YYYYMMDD[T]HHmm` (UTC). For example:
+`YYYYMMDD[T]HHmm` in the local time zone. For example:
 
 ```
 rustbelt solve-day --trip trips/example.json --day 2025-10-01 \

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -85,8 +85,8 @@ rustbelt solve-day --trip <file> --day <id> [options]
 - `--html [file]` – Emits an HTML itinerary to the given file or to stdout. Templates can be customized via `emitHtml`.
 
 Output paths support `${runId}` and `${timestamp}` tokens. These expand to the
-trip's `runId` (if any) and the solver run timestamp in `YYYYMMDD[T]HHmm` UTC
-format.
+trip's `runId` (if any) and the solver run timestamp in `YYYYMMDD[T]HHmm` local
+time format.
 
 Each KML placemark contains an `<ExtendedData>` block listing fields such as
 `id`, `type`, `arrive`, `depart`, `score`, `driveMin`, `distanceMi`,

--- a/src/time.ts
+++ b/src/time.ts
@@ -12,7 +12,7 @@ export function minToHhmm(min: number): string {
 export function formatTimestampToken(ts: string): string {
   const d = new Date(ts);
   const pad = (n: number, width = 2) => String(n).padStart(width, '0');
-  return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(
-    d.getUTCDate(),
-  )}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}${pad(d.getMinutes())}`;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -187,3 +187,47 @@ describe('CLI', () => {
     log.mockRestore();
   });
 });
+
+describe('timestamp token formatting', () => {
+  const iso = '2024-05-01T01:54:00.000Z';
+
+  const pad = (value: number, width = 2) => String(value).padStart(width, '0');
+
+  it('formats the timestamp token using the local time zone', () => {
+    const date = new Date(iso);
+    const expected = `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(
+      date.getDate(),
+    )}T${pad(date.getHours())}${pad(date.getMinutes())}`;
+    expect(formatTimestampToken(iso)).toBe(expected);
+  });
+
+  it('uses local getters rather than UTC getters when formatting', () => {
+    const getFullYear = vi.spyOn(Date.prototype, 'getFullYear');
+    const getMonth = vi.spyOn(Date.prototype, 'getMonth');
+    const getDate = vi.spyOn(Date.prototype, 'getDate');
+    const getHours = vi.spyOn(Date.prototype, 'getHours');
+    const getMinutes = vi.spyOn(Date.prototype, 'getMinutes');
+
+    const getUTCFullYear = vi.spyOn(Date.prototype, 'getUTCFullYear');
+    const getUTCMonth = vi.spyOn(Date.prototype, 'getUTCMonth');
+    const getUTCDate = vi.spyOn(Date.prototype, 'getUTCDate');
+    const getUTCHours = vi.spyOn(Date.prototype, 'getUTCHours');
+    const getUTCMinutes = vi.spyOn(Date.prototype, 'getUTCMinutes');
+
+    formatTimestampToken(iso);
+
+    expect(getFullYear).toHaveBeenCalled();
+    expect(getMonth).toHaveBeenCalled();
+    expect(getDate).toHaveBeenCalled();
+    expect(getHours).toHaveBeenCalled();
+    expect(getMinutes).toHaveBeenCalled();
+
+    expect(getUTCFullYear).not.toHaveBeenCalled();
+    expect(getUTCMonth).not.toHaveBeenCalled();
+    expect(getUTCDate).not.toHaveBeenCalled();
+    expect(getUTCHours).not.toHaveBeenCalled();
+    expect(getUTCMinutes).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Summary
- format `${timestamp}` tokens using local time getters so filenames reflect the host time zone
- document the timestamp placeholder as local time in the README and CLI guide
- add tests confirming the formatter relies on local getters rather than UTC getters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c59a2b6883289e22a8e0bdb14cd8