### PR TITLE
Add day-of planner template and script

### DIFF
--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -2,11 +2,22 @@ import { readFileSync } from 'fs';
 import Mustache from 'mustache';
 import type { DayPlan } from '../types';
 
-const defaultTemplate = readFileSync(
+const dayOfTemplate = readFileSync(
+  new URL('./templates/day-of.mustache', import.meta.url),
+  'utf8',
+);
+const dayOfPartials = {
+  dayOfScript: readFileSync(
+    new URL('./templates/day-of-script.mustache', import.meta.url),
+    'utf8',
+  ),
+};
+
+const legacyTemplate = readFileSync(
   new URL('./templates/itinerary.mustache', import.meta.url),
   'utf8',
 );
-const defaultPartials = {
+const legacyPartials = {
   stop: readFileSync(
     new URL('./templates/stop.mustache', import.meta.url),
     'utf8',
@@ -22,21 +33,47 @@ export interface EmitHtmlOptions {
   runId?: string;
   /** Optional run note */
   runNote?: string;
+  /** Render the legacy table layout */
+  legacyTable?: boolean;
+  /** Preferred active day identifier */
+  activeDayId?: string;
 }
 
-interface ViewModel {
+interface TemplateStop {
+  id: string;
+  arrive: string;
+  depart: string;
+  name: string;
+  type: string;
+  score?: string;
+  tags?: string;
+}
+
+interface TemplateDay {
+  dayId: string;
+  stops: TemplateStop[];
+  storeStops: TemplateStop[];
+  storeCount: number;
+}
+
+interface DayOfViewModel {
+  runTimestamp: string;
+  runId?: string;
+  runNote?: string;
+  itineraryJson: string;
+  days: TemplateDay[];
+  activeDayId?: string;
+  activeDay?: TemplateDay;
+  hasMultipleDays: boolean;
+}
+
+interface LegacyViewModel {
+  runTimestamp: string;
   runId?: string;
   runNote?: string;
   days: {
     dayId: string;
-    stops: {
-      arrive: string;
-      depart: string;
-      name: string;
-      type: string;
-      score?: string;
-      tags?: string;
-    }[];
+    stops: TemplateStop[];
   }[];
 }
 
@@ -45,24 +82,74 @@ export function emitHtml(
   runTimestamp = new Date().toISOString(),
   opts: EmitHtmlOptions = {},
 ): string {
-  const view: ViewModel & { runTimestamp: string } = {
+  const itineraryJson = JSON.stringify({
     runTimestamp,
     runId: opts.runId,
     runNote: opts.runNote,
-    days: days.map((d) => ({
-      dayId: d.dayId,
-      stops: d.stops.map((s) => ({
-        arrive: s.arrive,
-        depart: s.depart,
-        name: s.name,
-        type: s.type,
-        score: s.score != null ? s.score.toFixed(1) : undefined,
-        tags: s.tags?.join(', '),
+    days,
+  });
+
+  if (opts.legacyTable) {
+    const legacyView: LegacyViewModel = {
+      runTimestamp,
+      runId: opts.runId,
+      runNote: opts.runNote,
+      days: days.map((d) => ({
+        dayId: d.dayId,
+        stops: d.stops.map((s) => ({
+          id: s.id,
+          arrive: s.arrive,
+          depart: s.depart,
+          name: s.name,
+          type: s.type,
+          score: s.score != null ? s.score.toFixed(1) : undefined,
+          tags: s.tags?.join(', '),
+        })),
       })),
-    })),
+    };
+    const template = opts.template ?? legacyTemplate;
+    const partials = opts.partials ?? legacyPartials;
+    return Mustache.render(template, legacyView, partials);
+  }
+
+  const template = opts.template ?? dayOfTemplate;
+  const partials = opts.partials ?? dayOfPartials;
+
+  const templateDays: TemplateDay[] = days.map((d) => {
+    const stops = d.stops.map<TemplateStop>((s) => ({
+      id: s.id,
+      arrive: s.arrive,
+      depart: s.depart,
+      name: s.name,
+      type: s.type,
+      score: s.score != null ? s.score.toFixed(1) : undefined,
+      tags: s.tags?.join(', '),
+    }));
+    const storeStops = stops.filter((s) => s.type === 'store');
+    return {
+      dayId: d.dayId,
+      stops,
+      storeStops,
+      storeCount: storeStops.length,
+    };
+  });
+
+  const activeDay =
+    (opts.activeDayId && templateDays.find((d) => d.dayId === opts.activeDayId)) ||
+    templateDays.find((d) => d.storeStops.length > 0) ||
+    templateDays.find(() => true);
+
+  const view: DayOfViewModel = {
+    runTimestamp,
+    runId: opts.runId,
+    runNote: opts.runNote,
+    itineraryJson,
+    days: templateDays,
+    activeDayId: activeDay?.dayId,
+    activeDay,
+    hasMultipleDays: templateDays.length > 1,
   };
-  const template = opts.template ?? defaultTemplate;
-  const partials = opts.partials ?? defaultPartials;
+
   return Mustache.render(template, view, partials);
 }
 

--- a/src/io/templates/day-of-script.mustache
+++ b/src/io/templates/day-of-script.mustache
@@ -1,0 +1,774 @@
+<script>
+(function () {
+  'use strict';
+
+  const SCORE_MIN = 0;
+  const SCORE_MAX = 5;
+  const SCORE_RANGE = SCORE_MAX - SCORE_MIN;
+  const EPSILON = 1e-6;
+
+  const appState = {
+    itinerary: null,
+    stops: [],
+    currentIndex: 0,
+    log: [],
+    dayId: null,
+    mqaMap: {
+      Bust: 0.0,
+      Average: 3.5,
+      Good: 4.2,
+      Exceptional: 5.0,
+    },
+    posteriorConfig: {
+      priorStrength: 4,
+      baseAlpha: EPSILON,
+      baseBeta: EPSILON,
+      credibleZ: 1.0,
+      defaultScore: 3.5,
+    },
+    posteriorPool: {
+      observedAlpha: 0,
+      observedBeta: 0,
+      observationCount: 0,
+      totalObservedQuality: 0,
+      lastObservation: null,
+      lastThompson: null,
+    },
+  };
+
+  let spareNormal = null;
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    const dataElement = document.getElementById('itinerary-data');
+    if (!dataElement) {
+      console.error('Itinerary data script tag not found.');
+      return;
+    }
+
+    try {
+      appState.itinerary = JSON.parse(dataElement.textContent || '{}');
+    } catch (err) {
+      console.error('Failed to parse itinerary JSON.', err);
+      return;
+    }
+
+    const days = Array.isArray(appState.itinerary?.days)
+      ? appState.itinerary.days
+      : [];
+    const activeDayId = document.body?.dataset?.activeDayId;
+    const day =
+      (activeDayId && days.find((d) => d?.dayId === activeDayId)) ||
+      days.find((d) => Array.isArray(d?.stops) && d.stops.length > 0) ||
+      days.find(() => true);
+    if (!day) {
+      console.error('Unable to determine active day for itinerary.');
+      return;
+    }
+
+    appState.dayId = day.dayId ?? null;
+    if (document.body && appState.dayId) {
+      document.body.dataset.activeDayId = appState.dayId;
+    }
+
+    const dayLabel = document.getElementById('active-day-label');
+    if (dayLabel && day.dayId) {
+      dayLabel.textContent = `Day ${day.dayId}`;
+    }
+
+    const stops = Array.isArray(day.stops) ? day.stops : [];
+    appState.stops = stops
+      .filter((stop) => stop.type === 'store')
+      .map((stop) => ({
+        ...stop,
+        status: 'tovisit',
+        posterior: createPosterior(stop.score),
+      }));
+
+    appState.currentIndex = appState.stops.findIndex((s) => s.status === 'tovisit');
+    if (appState.currentIndex === -1) {
+      appState.currentIndex = appState.stops.length;
+    }
+
+    const runInfo = document.getElementById('run-info');
+    if (runInfo && appState.itinerary) {
+      const existing = runInfo.textContent?.trim();
+      if (!existing) {
+        const runId = appState.itinerary.runId ?? 'Unknown Run';
+        const runNote = appState.itinerary.runNote ? ` - ${appState.itinerary.runNote}` : '';
+        runInfo.textContent = `Run ID: ${runId}${runNote}`;
+      }
+    }
+
+    setupMQAOptions();
+    renderAll();
+    addEventListeners();
+  }
+
+  function setupMQAOptions() {
+    const container = document.getElementById('mqa-select');
+    if (!container) return;
+    container.innerHTML = '';
+    Object.entries(appState.mqaMap).forEach(([key, value]) => {
+      const div = document.createElement('div');
+      div.className = 'flex items-center p-3 rounded-lg border border-stone-200 hover:bg-stone-50';
+      div.innerHTML = `
+        <input id="mqa-${key.toLowerCase()}" type="radio" name="mqa" value="${key}" class="h-4 w-4 text-teal-600 border-stone-300 focus:ring-teal-500">
+        <label for="mqa-${key.toLowerCase()}" class="ml-3 block text-sm font-medium text-stone-700">
+          ${key} <span class="text-xs text-stone-500">(${value.toFixed(1)})</span>
+        </label>
+      `;
+      container.appendChild(div);
+    });
+  }
+
+  function renderAll() {
+    const currentStop = appState.stops[appState.currentIndex];
+    const metrics = calculateMetrics(currentStop?.id);
+    renderDashboard(metrics);
+    renderItineraryList(currentStop);
+    renderCurrentStore(currentStop);
+    renderTripLog();
+  }
+
+  function calculateMetrics(excludeId) {
+    const totalStores = appState.stops.length;
+    const visitedStores = appState.stops.filter((s) => s.status === 'visited').length;
+    const overallAvgScore =
+      totalStores > 0
+        ? (
+            appState.stops.reduce(
+              (sum, s) => sum + (typeof s.score === 'number' ? s.score : appState.posteriorConfig.defaultScore),
+              0,
+            ) / totalStores
+          ).toFixed(1)
+        : '0.0';
+
+    const poolPosterior = computeRemainingPoolPosterior(excludeId);
+    const currentStop = appState.stops[appState.currentIndex];
+
+    return {
+      totalStores,
+      visitedStores,
+      overallAvgScore,
+      poolPosterior,
+      currentPosterior: currentStop ? currentStop.posterior : null,
+      expectedRemQuality: poolPosterior ? poolPosterior.mean.toFixed(2) : '0.0',
+    };
+  }
+
+  function renderDashboard(metrics) {
+    const {
+      totalStores,
+      visitedStores,
+      overallAvgScore,
+      poolPosterior,
+      currentPosterior,
+    } = metrics;
+
+    setText('dashboard-total-stores', totalStores);
+    setText('dashboard-stores-visited', visitedStores);
+    setText('dashboard-avg-jscore', overallAvgScore);
+    setText(
+      'dashboard-expected-quality',
+      poolPosterior ? poolPosterior.mean.toFixed(2) : '--',
+    );
+    setText(
+      'dashboard-pool-uncertainty',
+      poolPosterior ? `±${poolPosterior.std.toFixed(2)}` : '±--',
+    );
+    setText(
+      'dashboard-current-mean',
+      currentPosterior ? currentPosterior.mean.toFixed(2) : '--',
+    );
+    setText(
+      'dashboard-current-uncertainty',
+      currentPosterior ? `±${currentPosterior.std.toFixed(2)}` : '±--',
+    );
+    setText(
+      'dashboard-current-thompson',
+      currentPosterior?.lastThompson != null
+        ? currentPosterior.lastThompson.toFixed(2)
+        : '--',
+    );
+    setText(
+      'dashboard-pool-thompson',
+      poolPosterior?.lastThompson != null ? poolPosterior.lastThompson.toFixed(2) : '--',
+    );
+  }
+
+  function renderItineraryList(currentStop) {
+    const container = document.getElementById('itinerary-list');
+    if (!container) return;
+    container.innerHTML = '';
+    appState.stops.forEach((stop, index) => {
+      const isCurrent = currentStop && stop.id === currentStop.id && stop.status === 'tovisit';
+      const div = document.createElement('div');
+      div.id = `row-${stop.id}`;
+      div.className = `p-3 rounded-md transition-all duration-300 ease-in-out status-${stop.status} ${
+        isCurrent ? 'ring-2 ring-teal-500 shadow-md' : 'shadow-sm'
+      }`;
+      const posteriorMean = stop.posterior ? stop.posterior.mean.toFixed(2) : formatScore(stop.score);
+      const posteriorStd = stop.posterior ? stop.posterior.std.toFixed(2) : '0.00';
+      const statusLabel =
+        stop.status === 'visited'
+          ? `Visited – ${stop.mqa ?? 'n/a'}`
+          : stop.status === 'dropped'
+          ? 'Dropped'
+          : 'To Visit';
+      div.innerHTML = `
+        <div class="flex justify-between items-start">
+          <div>
+            <p class="font-semibold">${stop.name}</p>
+            <p class="text-xs text-stone-500">${statusLabel}</p>
+          </div>
+          <div class="text-right">
+            <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">${posteriorMean}</p>
+            <p class="text-xs text-stone-500">±${posteriorStd}</p>
+          </div>
+        </div>
+      `;
+      container.appendChild(div);
+    });
+  }
+
+  function renderCurrentStore(currentStop) {
+    const nameEl = document.getElementById('current-store-name');
+    const form = document.getElementById('mqa-form');
+    if (!nameEl || !form) return;
+
+    if (!currentStop || currentStop.status !== 'tovisit') {
+      nameEl.textContent = 'Trip Complete!';
+      form.style.display = 'none';
+      setText('timeline-arrive-time', '--:--');
+      setText('timeline-mqa-time', '--:--');
+      return;
+    }
+
+    form.style.display = 'block';
+    nameEl.textContent = currentStop.name;
+
+    const [arriveH, arriveM] = currentStop.arrive.split(':').map(Number);
+    const mqaTime = new Date();
+    mqaTime.setHours(arriveH, arriveM + 30, 0, 0);
+    const mqaH = String(mqaTime.getHours()).padStart(2, '0');
+    const mqaM = String(mqaTime.getMinutes()).padStart(2, '0');
+
+    setText('timeline-arrive-time', currentStop.arrive);
+    setText('timeline-mqa-time', `${mqaH}:${mqaM}`);
+  }
+
+  function renderTripLog() {
+    const container = document.getElementById('trip-log');
+    if (!container) return;
+
+    if (appState.log.length === 0) {
+      container.innerHTML = '<p class="text-stone-500">Your decisions will appear here.</p>';
+      return;
+    }
+
+    container.innerHTML = '';
+    appState.log.forEach((entry) => {
+      const div = document.createElement('div');
+      div.className = 'p-2 border-b border-stone-100';
+      const posterior = entry.posterior;
+      const pool = entry.pool;
+      const mqaValueText = entry.mqaValue != null ? ` (${entry.mqaValue.toFixed(1)})` : '';
+      const zScoreText = entry.zScore != null ? ` | z=${entry.zScore.toFixed(2)}` : '';
+      div.innerHTML = `
+        <p class="font-medium">${entry.name}</p>
+        <p class="text-stone-600">MQA: <span class="font-semibold">${entry.mqa}</span>${mqaValueText} → Decision: <span class="font-semibold">${entry.decision}</span></p>
+        <p class="text-xs text-stone-500">Posterior μ=${posterior.mean.toFixed(2)} σ=${posterior.std.toFixed(2)} | Thompson=${
+          posterior.lastThompson != null ? posterior.lastThompson.toFixed(2) : '--'
+        } | Pool μ=${pool.mean.toFixed(2)} σ=${pool.std.toFixed(2)}${
+        pool.lastThompson != null ? ` | Pool Thompson=${pool.lastThompson.toFixed(2)}` : ''
+      }${zScoreText ? zScoreText : ''}</p>
+      `;
+      container.appendChild(div);
+    });
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function processDecision(mqaKey) {
+    const currentStop = appState.stops[appState.currentIndex];
+    if (!currentStop) return;
+
+    const mqaValue = appState.mqaMap[mqaKey];
+    if (typeof mqaValue !== 'number') {
+      console.warn('Unknown MQA key selected:', mqaKey);
+      return;
+    }
+
+    updateStopPosterior(currentStop, mqaValue);
+    updatePoolObservation(mqaValue);
+
+    const poolPosterior = computeRemainingPoolPosterior(currentStop.id);
+    const currentSample = drawThompsonSample(currentStop.posterior.alpha, currentStop.posterior.beta);
+    const poolSample = drawThompsonSample(poolPosterior.alpha, poolPosterior.beta);
+    const decisionMeta = getBayesianRecommendation(
+      currentStop.posterior,
+      poolPosterior,
+      mqaKey,
+      currentSample,
+      poolSample,
+    );
+    const recommendation = decisionMeta.decision;
+
+    currentStop.posterior.lastThompson = currentSample;
+    appState.posteriorPool.lastThompson = poolSample;
+    poolPosterior.lastThompson = poolSample;
+
+    updateRecommendationDisplay(recommendation, decisionMeta, currentStop.posterior, poolPosterior);
+
+    currentStop.mqa = mqaKey;
+    currentStop.mqaValue = mqaValue;
+    currentStop.decision = recommendation;
+    currentStop.decisionReason = decisionMeta.reason;
+    currentStop.status = 'visited';
+    currentStop.posteriorSummary = serializePosterior(currentStop.posterior);
+    currentStop.posteriorSummary.diff = decisionMeta.diff;
+    currentStop.posteriorSummary.zScore = decisionMeta.zScore;
+
+    appState.log.push({
+      name: currentStop.name,
+      mqa: mqaKey,
+      mqaValue,
+      decision: recommendation,
+      decisionReason: decisionMeta.reason,
+      diff: decisionMeta.diff,
+      zScore: decisionMeta.zScore,
+      posterior: serializePosterior(currentStop.posterior),
+      pool: serializePool(poolPosterior),
+      timestamp: new Date().toISOString(),
+    });
+
+    renderAll();
+
+    if (recommendation === 'Stay' && mqaKey === 'Exceptional') {
+      handleOverrun();
+    } else {
+      advanceToNextStore();
+    }
+  }
+
+  function updateRecommendationDisplay(recommendation, meta, currentPosterior, poolPosterior) {
+    const display = document.getElementById('recommendation-display');
+    if (!display) return;
+    const diffText = meta.diff != null ? `Δμ=${meta.diff.toFixed(2)}` : '';
+    const zText = meta.zScore != null && Number.isFinite(meta.zScore) ? `z=${meta.zScore.toFixed(2)}` : '';
+    const reason = humanizeReason(meta.reason);
+    const currentSummary = currentPosterior
+      ? `Current μ=${currentPosterior.mean.toFixed(2)} σ=${currentPosterior.std.toFixed(2)} Thompson=${
+          currentPosterior.lastThompson != null ? currentPosterior.lastThompson.toFixed(2) : '--'
+        }`
+      : '';
+    const poolSummary = poolPosterior
+      ? `Pool μ=${poolPosterior.mean.toFixed(2)} σ=${poolPosterior.std.toFixed(2)} Thompson=${
+          poolPosterior.lastThompson != null ? poolPosterior.lastThompson.toFixed(2) : '--'
+        }`
+      : '';
+
+    const metaLine = [reason, diffText, zText].filter(Boolean).join(' · ');
+    const summaryLine = [currentSummary, poolSummary].filter(Boolean).join(' | ');
+
+    display.innerHTML = `
+      <p class="text-lg font-medium">Recommendation:</p>
+      <p class="text-3xl font-bold recommendation-${recommendation.toLowerCase()}">${recommendation.toUpperCase()}</p>
+      <p class="text-sm text-stone-600">${metaLine}</p>
+      <p class="text-xs text-stone-500">${summaryLine}</p>
+    `;
+  }
+
+  function handleOverrun() {
+    const remainingStops = appState.stops.filter((s) => s.status === 'tovisit');
+    if (remainingStops.length === 0) {
+      advanceToNextStore();
+      return;
+    }
+
+    const lowestScoringStop = remainingStops.reduce((min, stop) =>
+      stop.posterior.mean < min.posterior.mean ? stop : min,
+    );
+
+    setTimeout(() => {
+      const confirmed = window.confirm(
+        `To extend your stay, drop the lowest-rated remaining store:\n\n${lowestScoringStop.name} (Posterior μ: ${lowestScoringStop.posterior.mean.toFixed(
+          2,
+        )})\n\nDrop this store?`,
+      );
+
+      if (confirmed) {
+        const stopToDrop = appState.stops.find((s) => s.id === lowestScoringStop.id);
+        if (stopToDrop) {
+          stopToDrop.status = 'dropped';
+          appState.log.push({
+            name: stopToDrop.name,
+            mqa: 'N/A',
+            mqaValue: null,
+            decision: 'Dropped',
+            decisionReason: 'overrun-drop-lowest',
+            diff: null,
+            zScore: null,
+            posterior: serializePosterior(stopToDrop.posterior),
+            pool: serializePool(computeRemainingPoolPosterior()),
+            timestamp: new Date().toISOString(),
+          });
+        }
+      }
+      advanceToNextStore();
+    }, 500);
+  }
+
+  function advanceToNextStore() {
+    let nextIndex = appState.currentIndex + 1;
+    while (nextIndex < appState.stops.length && appState.stops[nextIndex].status !== 'tovisit') {
+      nextIndex += 1;
+    }
+    appState.currentIndex = nextIndex;
+
+    const selectedRadio = document.querySelector('input[name="mqa"]:checked');
+    if (selectedRadio) selectedRadio.checked = false;
+    const display = document.getElementById('recommendation-display');
+    if (display) display.innerHTML = '';
+
+    renderAll();
+  }
+
+  function addEventListeners() {
+    const decisionButton = document.getElementById('decision-button');
+    if (decisionButton) {
+      decisionButton.addEventListener('click', () => {
+        const selectedMQA = document.querySelector('input[name="mqa"]:checked');
+        if (!selectedMQA) {
+          window.alert('Please select a Measured Quality Assessment (MQA).');
+          return;
+        }
+        processDecision(selectedMQA.value);
+      });
+    }
+
+    const bustButton = document.getElementById('bust-button');
+    if (bustButton) {
+      bustButton.addEventListener('click', () => {
+        processDecision('Bust');
+      });
+    }
+
+    const exportButton = document.getElementById('export-button');
+    if (exportButton) {
+      exportButton.addEventListener('click', () => {
+        const poolSnapshot = computeRemainingPoolPosterior();
+        const exportData = {
+          runInfo: appState.itinerary,
+          activeDayId: appState.dayId,
+          finalStopsState: appState.stops.map((stop) => ({
+            id: stop.id,
+            name: stop.name,
+            type: stop.type,
+            arrive: stop.arrive,
+            depart: stop.depart,
+            score: stop.score,
+            status: stop.status,
+            mqa: stop.mqa ?? null,
+            mqaValue: stop.mqaValue ?? null,
+            decision: stop.decision ?? null,
+            decisionReason: stop.decisionReason ?? null,
+            posterior: serializePosterior(stop.posterior),
+          })),
+          tripLog: appState.log,
+          posteriorPool: {
+            ...serializePool(poolSnapshot),
+            observedAlpha: appState.posteriorPool.observedAlpha,
+            observedBeta: appState.posteriorPool.observedBeta,
+            observationCount: appState.posteriorPool.observationCount,
+            totalObservedQuality: appState.posteriorPool.totalObservedQuality,
+          },
+          posteriorConfig: appState.posteriorConfig,
+        };
+        const dataStr = JSON.stringify(exportData, null, 2);
+        const dataBlob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(dataBlob);
+        const a = document.createElement('a');
+        a.href = url;
+        const runId = appState.itinerary?.runId ?? 'trip';
+        a.download = `rust-belt-trip-${runId}-results.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      });
+    }
+  }
+
+  function getBayesianRecommendation(currentPosterior, poolPosterior, mqaKey, currentSample, poolSample) {
+    if (mqaKey === 'Bust') {
+      return { decision: 'Leave', reason: 'mqa-bust', diff: -Infinity, zScore: null, currentSample, poolSample };
+    }
+    if (!currentPosterior) {
+      return { decision: 'Leave', reason: 'no-current-posterior', diff: null, zScore: null, currentSample, poolSample };
+    }
+    if (!poolPosterior || poolPosterior.count === 0) {
+      return { decision: 'Stay', reason: 'no-remaining-stops', diff: currentPosterior.mean, zScore: null, currentSample, poolSample };
+    }
+
+    const diff = currentPosterior.mean - poolPosterior.mean;
+    const combinedStd = Math.sqrt(
+      currentPosterior.std * currentPosterior.std + poolPosterior.std * poolPosterior.std,
+    );
+    const zScore = combinedStd > 0 ? diff / combinedStd : diff >= 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+
+    if (currentPosterior.lower >= poolPosterior.upper) {
+      return { decision: 'Stay', reason: 'posterior-dominates', diff, zScore, currentSample, poolSample };
+    }
+    if (poolPosterior.lower >= currentPosterior.upper) {
+      return { decision: 'Leave', reason: 'pool-dominates', diff, zScore, currentSample, poolSample };
+    }
+    if (currentSample >= poolSample) {
+      return { decision: 'Stay', reason: 'thompson-preference', diff, zScore, currentSample, poolSample };
+    }
+    if (diff >= 0 && zScore >= -0.25) {
+      return { decision: 'Stay', reason: 'expected-value-edge', diff, zScore, currentSample, poolSample };
+    }
+    return { decision: 'Leave', reason: 'expected-value-deficit', diff, zScore, currentSample, poolSample };
+  }
+
+  function computeRemainingPoolPosterior(excludeId) {
+    const remainingStops = appState.stops.filter(
+      (s) => s.status === 'tovisit' && (!excludeId || s.id !== excludeId),
+    );
+
+    let pseudoAlpha = 0;
+    let pseudoBeta = 0;
+    remainingStops.forEach((stop) => {
+      const priorNorm = stop.posterior?.priorNormalized ?? normalizeScore(stop.score);
+      const pseudo = stop.posterior?.pseudo ?? appState.posteriorConfig.priorStrength;
+      pseudoAlpha += priorNorm * pseudo;
+      pseudoBeta += (1 - priorNorm) * pseudo;
+    });
+
+    const alpha = appState.posteriorConfig.baseAlpha + pseudoAlpha + appState.posteriorPool.observedAlpha;
+    const beta = appState.posteriorConfig.baseBeta + pseudoBeta + appState.posteriorPool.observedBeta;
+    const stats = computeBetaStats(alpha, beta);
+    return {
+      ...stats,
+      count: remainingStops.length,
+      pseudoAlpha,
+      pseudoBeta,
+      observationCount: appState.posteriorPool.observationCount,
+      totalObservedQuality: appState.posteriorPool.totalObservedQuality,
+      lastThompson: appState.posteriorPool.lastThompson,
+    };
+  }
+
+  function createPosterior(baseScore) {
+    const normalized = normalizeScore(baseScore);
+    const pseudo = appState.posteriorConfig.priorStrength;
+    const posterior = {
+      alpha: appState.posteriorConfig.baseAlpha + normalized * pseudo,
+      beta: appState.posteriorConfig.baseBeta + (1 - normalized) * pseudo,
+      priorNormalized: normalized,
+      pseudo,
+      observationCount: 0,
+      totalQuality: 0,
+      lastObservation: null,
+      lastThompson: null,
+    };
+    return recomputePosteriorStats(posterior);
+  }
+
+  function updateStopPosterior(stop, mqaValue) {
+    const normalized = normalizeScore(mqaValue);
+    stop.posterior.alpha += normalized;
+    stop.posterior.beta += 1 - normalized;
+    stop.posterior.observationCount = (stop.posterior.observationCount ?? 0) + 1;
+    stop.posterior.totalQuality = (stop.posterior.totalQuality ?? 0) + mqaValue;
+    stop.posterior.lastObservation = mqaValue;
+    recomputePosteriorStats(stop.posterior);
+  }
+
+  function updatePoolObservation(mqaValue) {
+    const normalized = normalizeScore(mqaValue);
+    appState.posteriorPool.observedAlpha += normalized;
+    appState.posteriorPool.observedBeta += 1 - normalized;
+    appState.posteriorPool.observationCount += 1;
+    appState.posteriorPool.totalObservedQuality += mqaValue;
+    appState.posteriorPool.lastObservation = mqaValue;
+  }
+
+  function recomputePosteriorStats(posterior) {
+    posterior.alpha = Math.max(posterior.alpha, EPSILON);
+    posterior.beta = Math.max(posterior.beta, EPSILON);
+    const total = posterior.alpha + posterior.beta;
+    const meanNormalized = posterior.alpha / total;
+    const varianceNormalized = (posterior.alpha * posterior.beta) / ((total + 1) * total * total);
+    const stdScore = Math.sqrt(Math.max(varianceNormalized, 0)) * SCORE_RANGE;
+    posterior.meanNormalized = meanNormalized;
+    posterior.mean = denormalizeScore(meanNormalized);
+    posterior.std = stdScore;
+    posterior.lower = clamp(
+      posterior.mean - appState.posteriorConfig.credibleZ * stdScore,
+      SCORE_MIN,
+      SCORE_MAX,
+    );
+    posterior.upper = clamp(
+      posterior.mean + appState.posteriorConfig.credibleZ * stdScore,
+      SCORE_MIN,
+      SCORE_MAX,
+    );
+    posterior.variance = stdScore * stdScore;
+    return posterior;
+  }
+
+  function computeBetaStats(alpha, beta) {
+    const safeAlpha = Math.max(alpha, EPSILON);
+    const safeBeta = Math.max(beta, EPSILON);
+    const total = safeAlpha + safeBeta;
+    const meanNormalized = safeAlpha / total;
+    const varianceNormalized = (safeAlpha * safeBeta) / ((total + 1) * total * total);
+    const stdScore = Math.sqrt(Math.max(varianceNormalized, 0)) * SCORE_RANGE;
+    const meanScore = denormalizeScore(meanNormalized);
+    const lower = clamp(
+      meanScore - appState.posteriorConfig.credibleZ * stdScore,
+      SCORE_MIN,
+      SCORE_MAX,
+    );
+    const upper = clamp(
+      meanScore + appState.posteriorConfig.credibleZ * stdScore,
+      SCORE_MIN,
+      SCORE_MAX,
+    );
+    return {
+      alpha: safeAlpha,
+      beta: safeBeta,
+      meanNormalized,
+      mean: meanScore,
+      std: stdScore,
+      variance: stdScore * stdScore,
+      lower,
+      upper,
+    };
+  }
+
+  function serializePosterior(posterior) {
+    return {
+      alpha: posterior.alpha,
+      beta: posterior.beta,
+      mean: posterior.mean,
+      meanNormalized: posterior.meanNormalized,
+      std: posterior.std,
+      variance: posterior.variance,
+      lower: posterior.lower,
+      upper: posterior.upper,
+      observationCount: posterior.observationCount ?? 0,
+      totalQuality: posterior.totalQuality ?? 0,
+      lastObservation: posterior.lastObservation ?? null,
+      lastThompson: posterior.lastThompson ?? null,
+      priorNormalized: posterior.priorNormalized ?? null,
+      pseudo: posterior.pseudo ?? appState.posteriorConfig.priorStrength,
+    };
+  }
+
+  function serializePool(poolPosterior) {
+    return {
+      alpha: poolPosterior.alpha,
+      beta: poolPosterior.beta,
+      mean: poolPosterior.mean,
+      meanNormalized: poolPosterior.meanNormalized,
+      std: poolPosterior.std,
+      variance: poolPosterior.variance,
+      lower: poolPosterior.lower,
+      upper: poolPosterior.upper,
+      count: poolPosterior.count,
+      pseudoAlpha: poolPosterior.pseudoAlpha,
+      pseudoBeta: poolPosterior.pseudoBeta,
+      observationCount: poolPosterior.observationCount,
+      totalObservedQuality: poolPosterior.totalObservedQuality,
+      lastThompson: poolPosterior.lastThompson ?? null,
+    };
+  }
+
+  function setText(id, value) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.textContent = value;
+  }
+
+  function normalizeScore(value) {
+    const safeValue = typeof value === 'number' ? value : appState.posteriorConfig.defaultScore;
+    return clamp((safeValue - SCORE_MIN) / SCORE_RANGE, 0, 1);
+  }
+
+  function denormalizeScore(normalized) {
+    return SCORE_MIN + clamp(normalized, 0, 1) * SCORE_RANGE;
+  }
+
+  function formatScore(value) {
+    if (typeof value !== 'number') return '0.0';
+    return value.toFixed(1);
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function drawThompsonSample(alpha, beta) {
+    const sample = sampleBeta(alpha, beta);
+    return denormalizeScore(sample);
+  }
+
+  function sampleBeta(alpha, beta) {
+    const x = sampleGamma(alpha);
+    const y = sampleGamma(beta);
+    if (x + y === 0) return 0.5;
+    return x / (x + y);
+  }
+
+  function sampleGamma(shape) {
+    const safeShape = Math.max(shape, EPSILON);
+    if (safeShape < 1) {
+      const u = Math.random();
+      return sampleGamma(safeShape + 1) * Math.pow(u, 1 / safeShape);
+    }
+    const d = safeShape - 1 / 3;
+    const c = 1 / Math.sqrt(9 * d);
+    while (true) {
+      let x;
+      let v;
+      do {
+        x = sampleStandardNormal();
+        v = 1 + c * x;
+      } while (v <= 0);
+      v = v * v * v;
+      const u = Math.random();
+      if (u < 1 - 0.0331 * x * x * x * x) return d * v;
+      if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+    }
+  }
+
+  function sampleStandardNormal() {
+    if (spareNormal != null) {
+      const value = spareNormal;
+      spareNormal = null;
+      return value;
+    }
+    let u = 0;
+    let v = 0;
+    while (u === 0) u = Math.random();
+    while (v === 0) v = Math.random();
+    const mag = Math.sqrt(-2.0 * Math.log(u));
+    const z0 = mag * Math.cos(2 * Math.PI * v);
+    const z1 = mag * Math.sin(2 * Math.PI * v);
+    spareNormal = z1;
+    return z0;
+  }
+
+  function humanizeReason(reason) {
+    if (!reason) return '';
+    const text = reason
+      .replace(/[-_]/g, ' ')
+      .replace(/\b([a-z])/g, (m) => m.toUpperCase());
+    return text.replace(/\bMqa\b/g, 'MQA');
+  }
+})();
+</script>

--- a/src/io/templates/day-of.mustache
+++ b/src/io/templates/day-of.mustache
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rust Belt Bandit Planner</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        font-family: 'Inter', sans-serif;
+        background-color: #f5f5f4;
+      }
+      .status-tovisit {
+        background-color: white;
+      }
+      .status-visited {
+        background-color: #dcfce7;
+        color: #166534;
+      }
+      .status-dropped {
+        background-color: #fee2e2;
+        color: #991b1b;
+        text-decoration: line-through;
+      }
+      .recommendation-stay {
+        color: #0f766e;
+      }
+      .recommendation-leave {
+        color: #be123c;
+      }
+    </style>
+  </head>
+  <body class="text-stone-800" {{#activeDayId}}data-active-day-id="{{activeDayId}}"{{/activeDayId}}>
+    <script id="itinerary-data" type="application/json">{{{itineraryJson}}}</script>
+    <div class="container mx-auto p-4 md:p-6 lg:p-8">
+      <header class="mb-6">
+        <h1 class="text-3xl font-bold text-stone-900">Rust Belt Bandit Planner</h1>
+        <div id="run-info" class="text-stone-600 mt-1 text-sm space-x-0">
+          {{#runId}}
+          <span class="font-semibold">Run ID:</span>
+          <span class="ml-1">{{runId}}</span>
+          {{/runId}}
+          {{#runNote}}
+          <span class="{{#runId}}ml-2{{/runId}}{{^runId}}block mt-1{{/runId}} text-stone-500">{{runNote}}</span>
+          {{/runNote}}
+        </div>
+        <p class="text-xs text-stone-500 mt-1">Generated {{runTimestamp}}</p>
+        {{#activeDayId}}
+        <p id="active-day-label" class="text-sm text-stone-600 mt-2">Day {{activeDayId}}</p>
+        {{/activeDayId}}
+        {{#hasMultipleDays}}
+        <div class="mt-2 flex flex-wrap gap-2 text-xs text-stone-500" aria-label="Available days">
+          {{#days}}
+          <span class="px-2 py-1 rounded-full bg-stone-200 text-stone-700" data-day-id="{{dayId}}">{{dayId}}</span>
+          {{/days}}
+        </div>
+        {{/hasMultipleDays}}
+      </header>
+      <main class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <section class="lg:col-span-1 bg-white p-4 rounded-lg shadow-sm">
+          <h2 class="text-xl font-semibold mb-3">Itinerary</h2>
+          <div id="itinerary-list" class="space-y-2">
+            {{#activeDay}}
+            {{#storeStops}}
+            <div
+              class="p-3 rounded-md shadow-sm status-tovisit"
+              data-stop-id="{{id}}"
+              data-stop-type="{{type}}"
+            >
+              <div class="flex justify-between items-start">
+                <div>
+                  <p class="font-semibold">{{name}}</p>
+                  <p class="text-xs text-stone-500">{{arrive}} – {{depart}}</p>
+                </div>
+                {{#score}}
+                <div class="text-right">
+                  <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">{{score}}</p>
+                </div>
+                {{/score}}
+              </div>
+            </div>
+            {{/storeStops}}
+            {{^storeStops}}
+            <p class="text-sm text-stone-500">No stores scheduled for this day.</p>
+            {{/storeStops}}
+            {{/activeDay}}
+            {{^activeDay}}
+            <p class="text-sm text-stone-500">No itinerary data available.</p>
+            {{/activeDay}}
+          </div>
+          <noscript>
+            <div class="mt-4 space-y-3 text-sm text-stone-600">
+              {{#days}}
+              <div>
+                <p class="font-semibold">Day {{dayId}}</p>
+                <ul class="list-disc list-inside text-xs text-stone-500">
+                  {{#stops}}
+                  <li>{{arrive}} – {{depart}} · {{name}} ({{type}})</li>
+                  {{/stops}}
+                </ul>
+              </div>
+              {{/days}}
+            </div>
+          </noscript>
+        </section>
+        <section class="lg:col-span-1 flex flex-col gap-6">
+          <div class="bg-white p-4 rounded-lg shadow-sm">
+            <h2 class="text-xl font-semibold mb-1">Current Stop</h2>
+            <p id="current-store-name" class="text-2xl font-bold text-teal-700">Loading...</p>
+            <div id="store-timeline" class="mt-4">
+              <h3 class="text-sm font-medium text-stone-600 mb-2">Visit Timeline</h3>
+              <div class="flex items-center justify-between text-xs text-center">
+                <div class="flex-1">
+                  <p id="timeline-arrive-time" class="font-semibold">--:--</p>
+                  <p class="text-stone-500">Arrive</p>
+                </div>
+                <div class="flex-1 border-t-2 border-dashed border-stone-300 mx-2"></div>
+                <div class="flex-1">
+                  <p id="timeline-mqa-time" class="font-semibold">--:--</p>
+                  <p class="text-stone-500">MQA Check-in</p>
+                </div>
+                <div class="flex-1 border-t-2 border-dashed border-stone-300 mx-2"></div>
+                <div class="flex-1">
+                  <p class="font-semibold">Now</p>
+                  <p class="text-stone-500">Decision</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="bg-white p-4 rounded-lg shadow-sm flex-grow">
+            <h2 class="text-xl font-semibold mb-3">Measured Quality Assessment (MQA)</h2>
+            <div id="mqa-form" class="space-y-3">
+              <p class="text-sm text-stone-600">
+                After 30 minutes, assess the store's quality:
+              </p>
+              <div id="mqa-select" class="grid grid-cols-2 gap-3"></div>
+              <div class="flex gap-3 pt-3">
+                <button
+                  id="decision-button"
+                  class="w-full bg-teal-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-teal-700 transition-colors"
+                >
+                  Process MQA
+                </button>
+                <button
+                  id="bust-button"
+                  class="w-1/2 bg-rose-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-rose-700 transition-colors"
+                >
+                  Bust!
+                </button>
+              </div>
+            </div>
+            <div id="recommendation-display" class="mt-4 text-center"></div>
+          </div>
+        </section>
+        <section class="lg:col-span-1 flex flex-col gap-6">
+          <div class="bg-white p-4 rounded-lg shadow-sm">
+            <h2 class="text-xl font-semibold mb-3">Dashboard</h2>
+            <div class="grid grid-cols-2 gap-4 text-center">
+              <div class="bg-stone-50 p-3 rounded-md">
+                <p class="text-2xl font-bold" id="dashboard-total-stores">0</p>
+                <p class="text-sm text-stone-600">Total Stores</p>
+              </div>
+              <div class="bg-stone-50 p-3 rounded-md">
+                <p class="text-2xl font-bold" id="dashboard-stores-visited">0</p>
+                <p class="text-sm text-stone-600">Stores Visited</p>
+              </div>
+              <div class="bg-stone-50 p-3 rounded-md">
+                <p class="text-2xl font-bold" id="dashboard-avg-jscore">0.0</p>
+                <p class="text-sm text-stone-600">Avg. J-Score</p>
+              </div>
+              <div class="bg-teal-50 p-3 rounded-md">
+                <p class="text-2xl font-bold text-teal-800" id="dashboard-expected-quality">0.0</p>
+                <p class="text-sm text-teal-700">Remaining Posterior μ</p>
+              </div>
+              <div class="bg-teal-50 p-3 rounded-md">
+                <p class="text-2xl font-bold text-teal-800" id="dashboard-pool-uncertainty">±0.0</p>
+                <p class="text-sm text-teal-700">Remaining Uncertainty σ</p>
+              </div>
+              <div class="bg-blue-50 p-3 rounded-md">
+                <p class="text-2xl font-bold text-blue-800" id="dashboard-current-mean">0.0</p>
+                <p class="text-sm text-blue-700">Current Posterior μ</p>
+              </div>
+              <div class="bg-blue-50 p-3 rounded-md">
+                <p class="text-2xl font-bold text-blue-800" id="dashboard-current-uncertainty">±0.0</p>
+                <p class="text-sm text-blue-700">Current Uncertainty σ</p>
+              </div>
+              <div class="bg-emerald-50 p-3 rounded-md col-span-2">
+                <p class="text-2xl font-bold text-emerald-800" id="dashboard-current-thompson">0.0</p>
+                <p class="text-sm text-emerald-700">Current Thompson Draw</p>
+              </div>
+              <div class="bg-teal-100 p-3 rounded-md col-span-2">
+                <p class="text-2xl font-bold text-teal-900" id="dashboard-pool-thompson">0.0</p>
+                <p class="text-sm text-teal-900">Remaining Thompson Draw</p>
+              </div>
+            </div>
+          </div>
+          <div class="bg-white p-4 rounded-lg shadow-sm flex-grow">
+            <h2 class="text-xl font-semibold mb-3">Trip Log</h2>
+            <div id="trip-log" class="text-sm space-y-2 overflow-y-auto h-48">
+              <p class="text-stone-500">Your decisions will appear here.</p>
+            </div>
+          </div>
+          <div class="bg-white p-4 rounded-lg shadow-sm">
+            <button
+              id="export-button"
+              class="w-full bg-stone-700 text-white font-bold py-2 px-4 rounded-lg hover:bg-stone-800 transition-colors"
+            >
+              Export Trip Data
+            </button>
+          </div>
+        </section>
+      </main>
+    </div>
+    {{> dayOfScript}}
+  </body>
+</html>

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -3,68 +3,86 @@ import { emitHtml } from '../src/io/emitHtml';
 import type { DayPlan } from '../src/types';
 
 describe('emitHtml', () => {
-  it('renders itinerary using template', () => {
-    const day: DayPlan = {
-      dayId: 'D1',
-      stops: [
-        {
-          id: 'S',
-          name: 'Start',
-          type: 'start',
-          arrive: '09:00',
-          depart: '09:00',
-          lat: 0,
-          lon: 0,
-        },
-        {
-          id: 'A',
-          name: 'Store A',
-          type: 'store',
-          arrive: '09:10',
-          depart: '09:20',
-          lat: 1,
-          lon: 2,
-          score: 1,
-        },
-        {
-          id: 'E',
-          name: 'End',
-          type: 'end',
-          arrive: '09:30',
-          depart: '09:30',
-          lat: 3,
-          lon: 4,
-        },
-      ],
-      excluded: [],
-      metrics: {
-        storeCount: 1,
-        storesVisited: 1,
-        visitedIds: ['A'],
-        totalScore: 1,
-        scorePerStore: 1,
-        scorePerMin: 0,
-        scorePerDriveMin: 0,
-        scorePerMile: 0,
-        totalDriveMin: 0,
-        totalDwellMin: 0,
-        slackMin: 0,
-        totalDistanceMiles: 0,
-        onTimeRisk: 0,
+  const day: DayPlan = {
+    dayId: 'D1',
+    stops: [
+      {
+        id: 'S',
+        name: 'Start',
+        type: 'start',
+        arrive: '09:00',
+        depart: '09:00',
+        lat: 0,
+        lon: 0,
       },
-    };
+      {
+        id: 'A',
+        name: 'Store A',
+        type: 'store',
+        arrive: '09:10',
+        depart: '09:20',
+        lat: 1,
+        lon: 2,
+        score: 1,
+      },
+      {
+        id: 'E',
+        name: 'End',
+        type: 'end',
+        arrive: '09:30',
+        depart: '09:30',
+        lat: 3,
+        lon: 4,
+      },
+    ],
+    excluded: [],
+    metrics: {
+      storeCount: 1,
+      storesVisited: 1,
+      visitedIds: ['A'],
+      totalScore: 1,
+      scorePerStore: 1,
+      scorePerMin: 0,
+      scorePerDriveMin: 0,
+      scorePerMile: 0,
+      totalDriveMin: 0,
+      totalDwellMin: 0,
+      slackMin: 0,
+      totalDistanceMiles: 0,
+      onTimeRisk: 0,
+    },
+  };
+
+  it('renders the day-of support template by default', () => {
     const runTs = '2024-01-01T00:00:00Z';
     const runId = 'test-id';
     const runNote = 'test note';
     const html = emitHtml([day], runTs, { runId, runNote });
-    expect(html).toContain('<h2>Day D1</h2>');
+
+    expect(html).toContain('Rust Belt Bandit Planner');
+    expect(html).toContain('Measured Quality Assessment (MQA)');
     expect(html).toContain('Store A');
+    expect(html).toContain(`data-active-day-id="${day.dayId}`);
+
+    const scriptMatch = html.match(
+      /<script id="itinerary-data" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(scriptMatch).not.toBeNull();
+    const itinerary = JSON.parse(scriptMatch![1]);
+    expect(itinerary.runTimestamp).toBe(runTs);
+    expect(itinerary.runId).toBe(runId);
+    expect(itinerary.runNote).toBe(runNote);
+    expect(Array.isArray(itinerary.days)).toBe(true);
+    expect(itinerary.days[0].dayId).toBe(day.dayId);
+  });
+
+  it('can render the legacy itinerary table when requested', () => {
+    const runTs = '2024-01-01T00:00:00Z';
+    const html = emitHtml([day], runTs, { legacyTable: true });
+
+    expect(html).toContain('<table>');
+    expect(html).toContain('<h2>Day D1</h2>');
     expect(html).toContain(runTs);
-    expect(html).toContain(runId);
-    expect(html).toContain(runNote);
-    // one row per stop inside tbody
-    const tbody = html.split('<tbody>')[1].split('</tbody>')[0];
-    const rows = tbody.match(/<tr>/g) || [];
-    expect(rows.length).toBe(3);
+    expect(html).not.toContain('id="itinerary-data"');
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -92,7 +92,7 @@ describe('CLI', () => {
     expect(String(log.mock.calls[0][0])).toContain('binding=');
     expect(String(log.mock.calls[0][0])).toContain('violations=');
     expect(String(log.mock.calls[1][0])).toContain('Excluded:');
-    expect(String(log.mock.calls[2][0])).toContain('<html>');
+    expect(String(log.mock.calls[2][0])).toContain('<html');
     expect(() => JSON.parse(log.mock.calls[3][0])).not.toThrow();
     log.mockRestore();
   });


### PR DESCRIPTION
## Summary
- add a day-of Mustache layout and companion script partial that renders the interactive planner shell with embedded itinerary JSON
- update emitHtml to populate the new view model, expose the JSON payload, and keep a legacy table fallback with optional active day selection
- refresh HTML emission and CLI tests to exercise the new template and legacy behaviour

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ca3a389d4c8328a269c8e9a5913b1a