### PR TITLE
Make day-of HTML output offline friendly

### DIFF
--- a/docs/day-of-support-prototype.html
+++ b/docs/day-of-support-prototype.html
@@ -4,24 +4,202 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rust Belt Bandit Planner</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Chosen Palette: Stone & Teal -->
-    <!-- Application Structure Plan: A responsive single-page application with a three-column layout on desktops/tablets and a single-column layout on mobile. The structure is task-oriented: (1) an itinerary overview on the left, (2) a central decision-support panel for the current store, and (3) a dynamic dashboard and log on the right. This design was chosen to present all relevant information for the core user task—making a "Stay" or "Leave" decision—without scrolling or navigation, maximizing usability in the field. -->
-    <!-- Visualization & Content Choices: The core information (itinerary, stats) is presented using structured HTML/CSS tables and cards. The key interaction is the MQA selection, which updates the state and provides a recommendation. Goal: Inform -> Method: Dynamic stat cards. Goal: Decision Support -> Method: Interactive panel with radio buttons and a clear recommendation display. Goal: Track Progress -> Method: Dynamic trip log and visual status updates on the itinerary list. This approach avoids complex charts, focusing on clear, actionable information display using vanilla JS and Tailwind CSS. -->
-    <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f5f5f4; /* stone-100 */
+        :root {
+            --stone-50: #fafaf9;
+            --stone-100: #f5f5f4;
+            --stone-200: #e7e5e4;
+            --stone-300: #d6d3d1;
+            --stone-500: #78716c;
+            --stone-600: #57534e;
+            --stone-700: #44403c;
+            --stone-800: #292524;
+            --stone-900: #1c1917;
+            --teal-50: #f0fdfa;
+            --teal-100: #ccfbf1;
+            --teal-600: #0d9488;
+            --teal-700: #0f766e;
+            --teal-800: #115e59;
+            --teal-900: #134e4a;
+            --blue-50: #eff6ff;
+            --blue-700: #1d4ed8;
+            --blue-800: #1e40af;
+            --emerald-50: #ecfdf5;
+            --emerald-700: #047857;
+            --emerald-800: #065f46;
+            --rose-600: #e11d48;
+            --rose-700: #be123c;
+            --ring-default: rgba(20, 184, 166, 0.45);
         }
-        .status-tovisit { background-color: white; }
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            background-color: var(--stone-100);
+            color: var(--stone-800);
+            line-height: 1.5;
+        }
+        h1, h2, h3 {
+            margin: 0;
+            font-weight: 600;
+            color: var(--stone-900);
+        }
+        p {
+            margin: 0;
+        }
+        button, input, select {
+            font: inherit;
+            color: inherit;
+        }
+        button {
+            border: none;
+        }
+        button:focus-visible, input:focus-visible {
+            outline: 2px solid var(--teal-600);
+            outline-offset: 2px;
+        }
+        .focus\:ring-teal-500:focus-visible {
+            outline: 2px solid rgba(20, 184, 166, 0.75);
+            outline-offset: 2px;
+        }
+        .container {
+            width: 100%;
+            margin-left: auto;
+            margin-right: auto;
+            padding-left: 1rem;
+            padding-right: 1rem;
+            max-width: 100%;
+        }
+        @media (min-width: 640px) {
+            .container { max-width: 640px; }
+        }
+        @media (min-width: 768px) {
+            .container { max-width: 768px; }
+            .md\:p-6 { padding: 1.5rem; }
+        }
+        @media (min-width: 1024px) {
+            .container { max-width: 1024px; }
+            .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+            .lg\:col-span-1 { grid-column: span 1 / span 1; }
+            .lg\:p-8 { padding: 2rem; }
+        }
+        @media (min-width: 1280px) {
+            .container { max-width: 1280px; }
+        }
+        .mx-auto { margin-left: auto; margin-right: auto; }
+        .mt-1 { margin-top: 0.25rem; }
+        .mt-2 { margin-top: 0.5rem; }
+        .mt-4 { margin-top: 1rem; }
+        .mb-1 { margin-bottom: 0.25rem; }
+        .mb-2 { margin-bottom: 0.5rem; }
+        .mb-3 { margin-bottom: 0.75rem; }
+        .mb-6 { margin-bottom: 1.5rem; }
+        .ml-1 { margin-left: 0.25rem; }
+        .ml-2 { margin-left: 0.5rem; }
+        .ml-3 { margin-left: 0.75rem; }
+        .pt-3 { padding-top: 0.75rem; }
+        .p-2 { padding: 0.5rem; }
+        .p-3 { padding: 0.75rem; }
+        .p-4 { padding: 1rem; }
+        .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+        .px-4 { padding-left: 1rem; padding-right: 1rem; }
+        .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+        .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+        .gap-2 { gap: 0.5rem; }
+        .gap-3 { gap: 0.75rem; }
+        .gap-4 { gap: 1rem; }
+        .gap-6 { gap: 1.5rem; }
+        .space-y-2 > * + * { margin-top: 0.5rem; }
+        .space-y-3 > * + * { margin-top: 0.75rem; }
+        .space-x-0 > * + * { margin-left: 0; }
+        .grid { display: grid; }
+        .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+        .grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .col-span-2 { grid-column: span 2 / span 2; }
+        .flex { display: flex; }
+        .flex-col { flex-direction: column; }
+        .flex-wrap { flex-wrap: wrap; }
+        .flex-1 { flex: 1 1 0%; }
+        .flex-grow { flex-grow: 1; }
+        .items-start { align-items: flex-start; }
+        .items-center { align-items: center; }
+        .justify-between { justify-content: space-between; }
+        .text-center { text-align: center; }
+        .text-right { text-align: right; }
+        .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+        .text-xs { font-size: 0.75rem; line-height: 1rem; }
+        .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+        .text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+        .text-2xl { font-size: 1.5rem; line-height: 2rem; }
+        .text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+        .font-medium { font-weight: 500; }
+        .font-semibold { font-weight: 600; }
+        .font-bold { font-weight: 700; }
+        .font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+        .text-white { color: #ffffff; }
+        .text-blue-700 { color: var(--blue-700); }
+        .text-blue-800 { color: var(--blue-800); }
+        .text-emerald-700 { color: var(--emerald-700); }
+        .text-emerald-800 { color: var(--emerald-800); }
+        .text-stone-500 { color: var(--stone-500); }
+        .text-stone-600 { color: var(--stone-600); }
+        .text-stone-700 { color: var(--stone-700); }
+        .text-stone-800 { color: var(--stone-800); }
+        .text-stone-900 { color: var(--stone-900); }
+        .text-teal-600 { color: var(--teal-600); }
+        .text-teal-700 { color: var(--teal-700); }
+        .text-teal-800 { color: var(--teal-800); }
+        .text-teal-900 { color: var(--teal-900); }
+        input[type='radio'].text-teal-600 { accent-color: var(--teal-600); }
+        .bg-white { background-color: #ffffff; }
+        .bg-stone-50 { background-color: var(--stone-50); }
+        .bg-stone-200 { background-color: var(--stone-200); }
+        .bg-stone-700 { background-color: var(--stone-700); }
+        .bg-teal-50 { background-color: var(--teal-50); }
+        .bg-teal-100 { background-color: var(--teal-100); }
+        .bg-teal-600 { background-color: var(--teal-600); }
+        .bg-blue-50 { background-color: var(--blue-50); }
+        .bg-emerald-50 { background-color: var(--emerald-50); }
+        .bg-rose-600 { background-color: var(--rose-600); }
+        .hover\:bg-teal-700:hover { background-color: var(--teal-700); }
+        .hover\:bg-rose-700:hover { background-color: var(--rose-700); }
+        .hover\:bg-stone-50:hover { background-color: var(--stone-50); }
+        .hover\:bg-stone-800:hover { background-color: var(--stone-800); }
+        .w-full { width: 100%; }
+        .w-1\/2 { width: 50%; }
+        .h-4 { height: 1rem; }
+        .w-4 { width: 1rem; }
+        .h-48 { height: 12rem; }
+        .overflow-y-auto { overflow-y: auto; }
+        .border { border: 1px solid var(--stone-200); }
+        .border-b { border-bottom: 1px solid currentColor; }
+        .border-t-2 { border-top: 2px solid currentColor; }
+        .border-dashed { border-style: dashed; }
+        .border-stone-100 { border-color: var(--stone-100); }
+        .border-stone-200 { border-color: var(--stone-200); }
+        .border-stone-300 { border-color: var(--stone-300); }
+        .rounded { border-radius: 0.25rem; }
+        .rounded-md { border-radius: 0.375rem; }
+        .rounded-lg { border-radius: 0.5rem; }
+        .rounded-full { border-radius: 9999px; }
+        .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08); }
+        .shadow-md { box-shadow: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -2px rgba(15, 23, 42, 0.1); }
+        .ring-2 { outline: 2px solid var(--ring-color, var(--ring-default)); outline-offset: 2px; }
+        .ring-teal-500 { --ring-color: rgba(20, 184, 166, 0.55); }
+        .transition-all, .transition-colors { transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+        .transition-all { transition-property: all; }
+        .transition-colors { transition-property: color, background-color, border-color, text-decoration-color, fill, stroke; }
+        .duration-300 { transition-duration: 300ms; }
+        .ease-in-out { transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+        .list-disc { list-style-type: disc; }
+        .list-inside { list-style-position: inside; }
+        .status-tovisit { background-color: #ffffff; }
         .status-visited { background-color: #dcfce7; color: #166534; }
         .status-dropped { background-color: #fee2e2; color: #991b1b; text-decoration: line-through; }
-        .recommendation-stay { color: #0f766e; } /* teal-700 */
-        .recommendation-leave { color: #be123c; } /* rose-700 */
+        .recommendation-stay { color: #0f766e; }
+        .recommendation-leave { color: #be123c; }
     </style>
 </head>
 <body class="text-stone-800">

--- a/docs/rust-belt-cli-documentation.md
+++ b/docs/rust-belt-cli-documentation.md
@@ -52,7 +52,7 @@ rustbelt solve-day --trip <file> --day <id> [options]
 | `--out <file>`           | Write itinerary JSON to this path (overwrite) |
 | `--kml [file]`           | Write KML to this path (or stdout)            |
 | `--csv <file>`           | Write store stops CSV to this path (includes tags column) |
-| `--html [file]`          | Write HTML itinerary to this path or stdout   |
+| `--html [file]`          | Write an offline-ready HTML itinerary with inline CSS/JS to this path or stdout |
 | `--robustness <factor>`  | Multiply travel times by this factor          |
 | `--risk-threshold <min>` | Slack threshold minutes for on-time risk      |
 
@@ -124,6 +124,8 @@ the `<ExtendedData>` entries.
 ## Output
 
 The solver prints the resulting itinerary as JSON, including a `runTimestamp` field for tracking when the plan was generated. If `--out` is specified, the JSON is also written to the provided path. Supplying `--kml` emits a KML representation to the given file or to stdout when no file is provided. Using `--csv` saves a CSV of all store stops. Passing `--html` writes an HTML itinerary to the given file or stdout; templates can be customized via `emitHtml`.
+
+The HTML renderer embeds the required stylesheet and decision-support script directly in the document. Opening the file in a browser works without network access because no external fonts, CDNs, or runtime fetches are required.
 
 After emitting the JSON, the CLI prints a one-line summary that includes any binding or violated limits (e.g., `binding=maxStops | violations=none`). See the [constraint diagnostics](rust-belt-output-guide.md#constraint-diagnostics) section of the output guide for definitions and examples of these diagnostics.
 

--- a/docs/rust-belt-test-plan.md
+++ b/docs/rust-belt-test-plan.md
@@ -140,6 +140,7 @@ jq -r '.stores[] | "\(.lat),\(.lon)"' trips/rust-belt.json | sort | uniq -d
 - **Objective blending** – experiment with `--lambda` to favor higher-score stores once scores are populated.
 - **Robustness factor** – `--robustness` > 1 inflates drive times and reduces slack.
 - **Risk view** – use `--risk-threshold` to highlight legs with slack below a chosen buffer.
+- **Offline itinerary review** – Generate an HTML report with `--html`, then disable the browser's network stack (e.g., DevTools offline mode) and reload the file. Confirm the styling, interactive MQA form, and trip log updates still function without internet access.
 
 ---
 

--- a/src/io/emitHtml.ts
+++ b/src/io/emitHtml.ts
@@ -7,6 +7,10 @@ const dayOfTemplate = readFileSync(
   'utf8',
 );
 const dayOfPartials = {
+  dayOfStyle: readFileSync(
+    new URL('./templates/day-of-style.mustache', import.meta.url),
+    'utf8',
+  ),
   dayOfScript: readFileSync(
     new URL('./templates/day-of-script.mustache', import.meta.url),
     'utf8',

--- a/src/io/templates/day-of-style.mustache
+++ b/src/io/templates/day-of-style.mustache
@@ -1,0 +1,461 @@
+<style>
+:root {
+  --stone-50: #fafaf9;
+  --stone-100: #f5f5f4;
+  --stone-200: #e7e5e4;
+  --stone-300: #d6d3d1;
+  --stone-500: #78716c;
+  --stone-600: #57534e;
+  --stone-700: #44403c;
+  --stone-800: #292524;
+  --stone-900: #1c1917;
+  --teal-50: #f0fdfa;
+  --teal-100: #ccfbf1;
+  --teal-600: #0d9488;
+  --teal-700: #0f766e;
+  --teal-800: #115e59;
+  --teal-900: #134e4a;
+  --blue-50: #eff6ff;
+  --blue-700: #1d4ed8;
+  --blue-800: #1e40af;
+  --emerald-50: #ecfdf5;
+  --emerald-700: #047857;
+  --emerald-800: #065f46;
+  --rose-600: #e11d48;
+  --rose-700: #be123c;
+  --ring-default: rgba(20, 184, 166, 0.45);
+}
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  background-color: var(--stone-100);
+  color: var(--stone-800);
+  line-height: 1.5;
+}
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--stone-900);
+}
+p {
+  margin: 0;
+}
+button,
+input,
+select {
+  font: inherit;
+  color: inherit;
+}
+button {
+  border: none;
+}
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--teal-600);
+  outline-offset: 2px;
+}
+.focus\:ring-teal-500:focus-visible {
+  outline: 2px solid rgba(20, 184, 166, 0.75);
+  outline-offset: 2px;
+}
+.container {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  max-width: 100%;
+}
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+  .md\:p-6 {
+    padding: 1.5rem;
+  }
+}
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .lg\:col-span-1 {
+    grid-column: span 1 / span 1;
+  }
+  .lg\:p-8 {
+    padding: 2rem;
+  }
+}
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+.mt-1 {
+  margin-top: 0.25rem;
+}
+.mt-2 {
+  margin-top: 0.5rem;
+}
+.mt-4 {
+  margin-top: 1rem;
+}
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+.ml-1 {
+  margin-left: 0.25rem;
+}
+.ml-2 {
+  margin-left: 0.5rem;
+}
+.ml-3 {
+  margin-left: 0.75rem;
+}
+.pt-3 {
+  padding-top: 0.75rem;
+}
+.p-2 {
+  padding: 0.5rem;
+}
+.p-3 {
+  padding: 0.75rem;
+}
+.p-4 {
+  padding: 1rem;
+}
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+.gap-2 {
+  gap: 0.5rem;
+}
+.gap-3 {
+  gap: 0.75rem;
+}
+.gap-4 {
+  gap: 1rem;
+}
+.gap-6 {
+  gap: 1.5rem;
+}
+.space-y-2 > * + * {
+  margin-top: 0.5rem;
+}
+.space-y-3 > * + * {
+  margin-top: 0.75rem;
+}
+.space-x-0 > * + * {
+  margin-left: 0;
+}
+.grid {
+  display: grid;
+}
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+.flex {
+  display: flex;
+}
+.flex-col {
+  flex-direction: column;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.flex-1 {
+  flex: 1 1 0%;
+}
+.flex-grow {
+  flex-grow: 1;
+}
+.items-start {
+  align-items: flex-start;
+}
+.items-center {
+  align-items: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.text-center {
+  text-align: center;
+}
+.text-right {
+  text-align: right;
+}
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+.font-medium {
+  font-weight: 500;
+}
+.font-semibold {
+  font-weight: 600;
+}
+.font-bold {
+  font-weight: 700;
+}
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+.text-white {
+  color: #ffffff;
+}
+.text-blue-700 {
+  color: var(--blue-700);
+}
+.text-blue-800 {
+  color: var(--blue-800);
+}
+.text-emerald-700 {
+  color: var(--emerald-700);
+}
+.text-emerald-800 {
+  color: var(--emerald-800);
+}
+.text-stone-500 {
+  color: var(--stone-500);
+}
+.text-stone-600 {
+  color: var(--stone-600);
+}
+.text-stone-700 {
+  color: var(--stone-700);
+}
+.text-stone-800 {
+  color: var(--stone-800);
+}
+.text-stone-900 {
+  color: var(--stone-900);
+}
+.text-teal-600 {
+  color: var(--teal-600);
+}
+.text-teal-700 {
+  color: var(--teal-700);
+}
+.text-teal-800 {
+  color: var(--teal-800);
+}
+.text-teal-900 {
+  color: var(--teal-900);
+}
+input[type='radio'].text-teal-600 {
+  accent-color: var(--teal-600);
+}
+.bg-white {
+  background-color: #ffffff;
+}
+.bg-stone-50 {
+  background-color: var(--stone-50);
+}
+.bg-stone-200 {
+  background-color: var(--stone-200);
+}
+.bg-stone-700 {
+  background-color: var(--stone-700);
+}
+.bg-teal-50 {
+  background-color: var(--teal-50);
+}
+.bg-teal-100 {
+  background-color: var(--teal-100);
+}
+.bg-teal-600 {
+  background-color: var(--teal-600);
+}
+.bg-blue-50 {
+  background-color: var(--blue-50);
+}
+.bg-emerald-50 {
+  background-color: var(--emerald-50);
+}
+.bg-rose-600 {
+  background-color: var(--rose-600);
+}
+.hover\:bg-teal-700:hover {
+  background-color: var(--teal-700);
+}
+.hover\:bg-rose-700:hover {
+  background-color: var(--rose-700);
+}
+.hover\:bg-stone-50:hover {
+  background-color: var(--stone-50);
+}
+.hover\:bg-stone-800:hover {
+  background-color: var(--stone-800);
+}
+.w-full {
+  width: 100%;
+}
+.w-1\/2 {
+  width: 50%;
+}
+.h-4 {
+  height: 1rem;
+}
+.w-4 {
+  width: 1rem;
+}
+.h-48 {
+  height: 12rem;
+}
+.overflow-y-auto {
+  overflow-y: auto;
+}
+.border {
+  border: 1px solid var(--stone-200);
+}
+.border-b {
+  border-bottom: 1px solid currentColor;
+}
+.border-t-2 {
+  border-top: 2px solid currentColor;
+}
+.border-dashed {
+  border-style: dashed;
+}
+.border-stone-100 {
+  border-color: var(--stone-100);
+}
+.border-stone-200 {
+  border-color: var(--stone-200);
+}
+.border-stone-300 {
+  border-color: var(--stone-300);
+}
+.rounded {
+  border-radius: 0.25rem;
+}
+.rounded-md {
+  border-radius: 0.375rem;
+}
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+.rounded-full {
+  border-radius: 9999px;
+}
+.shadow-sm {
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+.shadow-md {
+  box-shadow: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -2px rgba(15, 23, 42, 0.1);
+}
+.ring-2 {
+  outline: 2px solid var(--ring-color, var(--ring-default));
+  outline-offset: 2px;
+}
+.ring-teal-500 {
+  --ring-color: rgba(20, 184, 166, 0.55);
+}
+.transition-all,
+.transition-colors {
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+.transition-all {
+  transition-property: all;
+}
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+}
+.duration-300 {
+  transition-duration: 300ms;
+}
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+.list-disc {
+  list-style-type: disc;
+}
+.list-inside {
+  list-style-position: inside;
+}
+.status-tovisit {
+  background-color: #ffffff;
+}
+.status-visited {
+  background-color: #dcfce7;
+  color: #166534;
+}
+.status-dropped {
+  background-color: #fee2e2;
+  color: #991b1b;
+  text-decoration: line-through;
+}
+.recommendation-stay {
+  color: #0f766e;
+}
+.recommendation-leave {
+  color: #be123c;
+}
+</style>

--- a/src/io/templates/day-of.mustache
+++ b/src/io/templates/day-of.mustache
@@ -4,37 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rust Belt Bandit Planner</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <style>
-      body {
-        font-family: 'Inter', sans-serif;
-        background-color: #f5f5f4;
-      }
-      .status-tovisit {
-        background-color: white;
-      }
-      .status-visited {
-        background-color: #dcfce7;
-        color: #166534;
-      }
-      .status-dropped {
-        background-color: #fee2e2;
-        color: #991b1b;
-        text-decoration: line-through;
-      }
-      .recommendation-stay {
-        color: #0f766e;
-      }
-      .recommendation-leave {
-        color: #be123c;
-      }
-    </style>
+    {{> dayOfStyle}}
   </head>
   <body class="text-stone-800" {{#activeDayId}}data-active-day-id="{{activeDayId}}"{{/activeDayId}}>
     <script id="itinerary-data" type="application/json">{{{itineraryJson}}}</script>

--- a/tests/emitHtml.test.ts
+++ b/tests/emitHtml.test.ts
@@ -76,6 +76,17 @@ describe('emitHtml', () => {
     expect(itinerary.days[0].dayId).toBe(day.dayId);
   });
 
+  it('embeds inline assets without remote dependencies', () => {
+    const html = emitHtml([day], '2024-01-01T00:00:00Z');
+
+    expect(html).toContain('--stone-100');
+    expect(html).toContain('class="container');
+    expect(html).not.toMatch(/<script\s+src="https?:/);
+    expect(html).not.toMatch(/<link[^>]+https?:/);
+    expect(html).not.toContain('cdn.tailwindcss.com');
+    expect(html).not.toContain('fonts.googleapis.com');
+  });
+
   it('can render the legacy itinerary table when requested', () => {
     const runTs = '2024-01-01T00:00:00Z';
     const html = emitHtml([day], runTs, { legacyTable: true });


### PR DESCRIPTION
## Summary
- replace the Tailwind CDN in the day-of template with a reusable inline CSS partial and update the prototype HTML to match
- document the offline-ready HTML packaging and add a manual regression step for loading the report without network access
- add a regression test ensuring the emitted HTML has no remote script or stylesheet dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa0f6a4dc8328b5064f567d82e566