### PR TITLE
Link store names to Google Maps

### DIFF
--- a/src/io/templates/day-of-script.mustache
+++ b/src/io/templates/day-of-script.mustache
@@ -40,6 +40,32 @@
 
   document.addEventListener('DOMContentLoaded', init);
 
+  function createMapsUrl(stop) {
+    if (!stop) return null;
+
+    const queryParts = [];
+    const hasLat = typeof stop.lat === 'number' && Number.isFinite(stop.lat);
+    const hasLon = typeof stop.lon === 'number' && Number.isFinite(stop.lon);
+    if (hasLat && hasLon) {
+      queryParts.push(`${stop.lat},${stop.lon}`);
+    }
+
+    if (typeof stop.name === 'string' && stop.name.trim()) {
+      queryParts.push(stop.name.trim());
+    }
+
+    if (typeof stop.address === 'string' && stop.address.trim()) {
+      queryParts.push(stop.address.trim());
+    }
+
+    if (queryParts.length === 0) {
+      return null;
+    }
+
+    const query = encodeURIComponent(queryParts.join(' '));
+    return `https://www.google.com/maps/search/?api=1&query=${query}`;
+  }
+
   function init() {
     const dataElement = document.getElementById('itinerary-data');
     if (!dataElement) {
@@ -84,6 +110,7 @@
         ...stop,
         status: 'tovisit',
         posterior: createPosterior(stop.score),
+        mapsUrl: createMapsUrl(stop),
       }));
 
     appState.currentIndex = appState.stops.findIndex((s) => s.status === 'tovisit');
@@ -217,10 +244,13 @@
           : stop.status === 'dropped'
           ? 'Dropped'
           : 'To Visit';
+      const nameMarkup = stop.mapsUrl
+        ? `<a class="store-link" href="${stop.mapsUrl}" target="_blank" rel="noopener noreferrer">${stop.name}</a>`
+        : stop.name;
       div.innerHTML = `
         <div class="flex justify-between items-start">
           <div>
-            <p class="font-semibold">${stop.name}</p>
+            <p class="font-semibold">${nameMarkup}</p>
             <p class="text-xs text-stone-500">${statusLabel}</p>
           </div>
           <div class="text-right">
@@ -248,6 +278,9 @@
 
     form.style.display = 'block';
     nameEl.textContent = currentStop.name;
+    if (currentStop.mapsUrl) {
+      nameEl.innerHTML = `<a class="store-link" href="${currentStop.mapsUrl}" target="_blank" rel="noopener noreferrer">${currentStop.name}</a>`;
+    }
 
     const [arriveH, arriveM] = currentStop.arrive.split(':').map(Number);
     const mqaTime = new Date();
@@ -276,8 +309,11 @@
       const pool = entry.pool;
       const mqaValueText = entry.mqaValue != null ? ` (${entry.mqaValue.toFixed(1)})` : '';
       const zScoreText = entry.zScore != null ? ` | z=${entry.zScore.toFixed(2)}` : '';
+      const nameHtml = entry.mapsUrl
+        ? `<a class="store-link" href="${entry.mapsUrl}" target="_blank" rel="noopener noreferrer">${entry.name}</a>`
+        : entry.name;
       div.innerHTML = `
-        <p class="font-medium">${entry.name}</p>
+        <p class="font-medium">${nameHtml}</p>
         <p class="text-stone-600">MQA: <span class="font-semibold">${entry.mqa}</span>${mqaValueText} → Decision: <span class="font-semibold">${entry.decision}</span></p>
         <p class="text-xs text-stone-500">Posterior μ=${posterior.mean.toFixed(2)} σ=${posterior.std.toFixed(2)} | Thompson=${
           posterior.lastThompson != null ? posterior.lastThompson.toFixed(2) : '--'
@@ -332,6 +368,7 @@
 
     appState.log.push({
       name: currentStop.name,
+      mapsUrl: currentStop.mapsUrl,
       mqa: mqaKey,
       mqaValue,
       decision: recommendation,
@@ -404,6 +441,7 @@
           stopToDrop.status = 'dropped';
           appState.log.push({
             name: stopToDrop.name,
+            mapsUrl: stopToDrop.mapsUrl,
             mqa: 'N/A',
             mqaValue: null,
             decision: 'Dropped',

--- a/src/io/templates/day-of-style.mustache
+++ b/src/io/templates/day-of-style.mustache
@@ -47,6 +47,21 @@ h3 {
 p {
   margin: 0;
 }
+
+.store-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.store-link:hover {
+  text-decoration: underline;
+}
+
+.store-link:focus-visible {
+  outline: 2px solid var(--teal-600);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
 button,
 input,
 select {


### PR DESCRIPTION
## Summary
- generate Google Maps URLs for each stop and attach them to the itinerary state
- render store names as external links to their Google Maps locations in the itinerary, current stop header, and trip log
- add focused styling for store links so they keep the existing appearance with only a hover underline cue

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caaa6f62608328a8688d79a4cf676b