### PR TITLE
Add manual drop control to day-of itinerary

### DIFF
--- a/src/io/templates/day-of-script.mustache
+++ b/src/io/templates/day-of-script.mustache
@@ -241,15 +241,22 @@
       const nameMarkup = stop.mapsUrl
         ? `<a class="store-link" href="${stop.mapsUrl}" target="_blank" rel="noopener noreferrer">${stop.name}</a>`
         : stop.name;
+      const dropButtonHtml =
+        stop.status === 'tovisit'
+          ? `<button type="button" class="drop-store-button mt-1 transition-colors" data-drop-stop-id="${stop.id}">Drop store</button>`
+          : '';
       div.innerHTML = `
-        <div class="flex justify-between items-start">
+        <div class="flex justify-between items-start gap-3">
           <div>
             <p class="font-semibold">${nameMarkup}</p>
             <p class="text-xs text-stone-500">${statusLabel}</p>
           </div>
-          <div class="text-right">
-            <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">${posteriorMean}</p>
-            <p class="text-xs text-stone-500">±${posteriorStd}</p>
+          <div class="flex flex-col items-end text-right gap-1">
+            <div>
+              <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">${posteriorMean}</p>
+              <p class="text-xs text-stone-500">±${posteriorStd}</p>
+            </div>
+            ${dropButtonHtml}
           </div>
         </div>
       `;
@@ -419,6 +426,51 @@
     `;
   }
 
+  function dropStopById(stopId, reason) {
+    const normalizedId = String(stopId);
+    const stopIndex = appState.stops.findIndex((s) => String(s.id) === normalizedId);
+    if (stopIndex === -1) return null;
+
+    const stop = appState.stops[stopIndex];
+    if (stop.status !== 'tovisit') {
+      return null;
+    }
+
+    stop.status = 'dropped';
+    stop.decision = 'Dropped';
+    stop.decisionReason = reason;
+
+    const posteriorSummary = serializePosterior(stop.posterior);
+    stop.posteriorSummary = {
+      ...posteriorSummary,
+      diff: null,
+      zScore: null,
+      currentUcb: null,
+      remainingUcb: null,
+    };
+
+    const poolSnapshot = serializePool(computeRemainingPoolPosterior());
+
+    appState.log.push({
+      name: stop.name,
+      mapsUrl: stop.mapsUrl,
+      mqa: 'N/A',
+      mqaValue: null,
+      decision: 'Dropped',
+      decisionReason: reason,
+      diff: null,
+      zScore: null,
+      currentUcb: null,
+      remainingUcb: null,
+      observationCount: null,
+      posterior: posteriorSummary,
+      pool: poolSnapshot,
+      timestamp: new Date().toISOString(),
+    });
+
+    return { stop, index: stopIndex };
+  }
+
   function handleOverrun() {
     const remainingStops = appState.stops.filter((s) => s.status === 'tovisit');
     if (remainingStops.length === 0) {
@@ -438,23 +490,7 @@
       );
 
       if (confirmed) {
-        const stopToDrop = appState.stops.find((s) => s.id === lowestScoringStop.id);
-        if (stopToDrop) {
-          stopToDrop.status = 'dropped';
-          appState.log.push({
-            name: stopToDrop.name,
-            mapsUrl: stopToDrop.mapsUrl,
-            mqa: 'N/A',
-            mqaValue: null,
-            decision: 'Dropped',
-            decisionReason: 'overrun-drop-lowest',
-            diff: null,
-            zScore: null,
-            posterior: serializePosterior(stopToDrop.posterior),
-            pool: serializePool(computeRemainingPoolPosterior()),
-            timestamp: new Date().toISOString(),
-          });
-        }
+        dropStopById(lowestScoringStop.id, 'overrun-drop-lowest');
       }
       advanceToNextStore();
     }, 500);
@@ -492,6 +528,44 @@
     if (bustButton) {
       bustButton.addEventListener('click', () => {
         processDecision('Bust');
+      });
+    }
+
+    const itineraryList = document.getElementById('itinerary-list');
+    if (itineraryList) {
+      itineraryList.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+          return;
+        }
+        const button = target.closest('button[data-drop-stop-id]');
+        if (!button) {
+          return;
+        }
+        event.preventDefault();
+        const stopId = button.getAttribute('data-drop-stop-id');
+        if (!stopId) {
+          return;
+        }
+        const stop = appState.stops.find((s) => String(s.id) === stopId);
+        if (!stop || stop.status !== 'tovisit') {
+          return;
+        }
+        const confirmed = window.confirm(
+          `Drop ${stop.name}?\n\nThis will mark the store as dropped.`,
+        );
+        if (!confirmed) {
+          return;
+        }
+        const dropResult = dropStopById(stopId, 'manual-drop');
+        if (!dropResult) {
+          return;
+        }
+        if (dropResult.index === appState.currentIndex) {
+          advanceToNextStore();
+        } else {
+          renderAll();
+        }
       });
     }
 

--- a/src/io/templates/day-of-style.mustache
+++ b/src/io/templates/day-of-style.mustache
@@ -62,6 +62,28 @@ p {
   outline-offset: 2px;
   border-radius: 0.25rem;
 }
+
+.drop-store-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: var(--stone-500);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.drop-store-button:hover {
+  color: var(--rose-600);
+}
+
+.drop-store-button:focus-visible {
+  outline: 2px solid rgba(225, 29, 72, 0.45);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
 button,
 input,
 select {


### PR DESCRIPTION
## Summary
- add a subtle "Drop store" action to each to-visit stop with confirmation and logging
- refactor drop handling into a shared helper and reuse it for overrun drops
- style the drop control to remain low profile while still accessible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8838f3548328a854604f97d0a03f