### PR TITLE
Add pending drop confirmation flow for overrun stays

### DIFF
--- a/src/io/templates/day-of-script.mustache
+++ b/src/io/templates/day-of-script.mustache
@@ -13,6 +13,7 @@
     currentIndex: 0,
     log: [],
     dayId: null,
+    pendingDrop: null,
     mqaMap: {
       Bust: 0.0,
       Average: 3.5,
@@ -424,12 +425,86 @@
     const metaLine = [reason, diffText, zText].filter(Boolean).join(' · ');
     const summaryLine = [currentSummary, poolSummary].filter(Boolean).join(' | ');
 
-    display.innerHTML = `
+    let pendingDropMarkup = '';
+    const pendingDrop = appState.pendingDrop;
+    if (pendingDrop) {
+      const pendingStop = appState.stops.find(
+        (s) => String(s.id) === String(pendingDrop.stopId ?? pendingDrop.id),
+      );
+      if (pendingStop && pendingStop.status === 'tovisit') {
+        const nameMarkup = pendingStop.mapsUrl
+          ? `<a class="store-link" href="${pendingStop.mapsUrl}" target="_blank" rel="noopener noreferrer">${pendingStop.name}</a>`
+          : pendingStop.name;
+        const posteriorMean = pendingStop.posterior
+          ? pendingStop.posterior.mean.toFixed(2)
+          : formatScore(pendingStop.score);
+        const posteriorStd = pendingStop.posterior
+          ? pendingStop.posterior.std.toFixed(2)
+          : '0.00';
+        const scheduleParts = [];
+        if (pendingStop.arrive) {
+          scheduleParts.push(`Arrive ${pendingStop.arrive}`);
+        }
+        if (pendingStop.depart) {
+          scheduleParts.push(`Depart ${pendingStop.depart}`);
+        }
+        const scheduleLine =
+          scheduleParts.length > 0
+            ? `<p class="text-xs text-amber-800 mt-1">${scheduleParts.join(' · ')}</p>`
+            : '';
+
+        pendingDropMarkup = `
+      <div class="pending-drop-panel mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
+        <p class="font-semibold">Extend your stay?</p>
+        <p class="mt-1 text-sm">Drop the lowest-rated remaining store to stay longer.</p>
+        <div class="mt-2 text-sm">
+          <p class="font-medium">${nameMarkup}</p>
+          <p class="text-xs text-amber-800">Posterior μ=${posteriorMean} σ=${posteriorStd}</p>
+          ${scheduleLine}
+        </div>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="pending-drop-confirm rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+            data-action="confirm-pending-drop"
+            data-stop-id="${pendingStop.id}"
+          >
+            Drop this store
+          </button>
+          <button
+            type="button"
+            class="pending-drop-cancel rounded-md border border-amber-400 px-3 py-2 text-sm font-semibold text-amber-900 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
+            data-action="cancel-pending-drop"
+          >
+            Keep all future stores
+          </button>
+        </div>
+      </div>
+    `;
+      } else {
+        appState.pendingDrop = null;
+      }
+    }
+
+    const baseMarkup = `
       <p class="text-lg font-medium">Recommendation:</p>
       <p class="text-3xl font-bold recommendation-${recommendation.toLowerCase()}">${recommendation.toUpperCase()}</p>
       <p class="text-sm text-stone-600">${metaLine}</p>
       <p class="text-xs text-stone-500">${summaryLine}</p>
     `;
+
+    display.innerHTML = `${baseMarkup}${pendingDropMarkup}`;
+
+    if (pendingDropMarkup) {
+      const confirmButton = display.querySelector('[data-action="confirm-pending-drop"]');
+      if (confirmButton) {
+        confirmButton.addEventListener('click', confirmPendingDrop);
+      }
+      const cancelButton = display.querySelector('[data-action="cancel-pending-drop"]');
+      if (cancelButton) {
+        cancelButton.addEventListener('click', cancelPendingDrop);
+      }
+    }
   }
 
   function dropStopById(stopId, reason) {
@@ -474,6 +549,13 @@
       timestamp: new Date().toISOString(),
     });
 
+    if (
+      appState.pendingDrop &&
+      String(appState.pendingDrop.stopId ?? appState.pendingDrop.id) === normalizedId
+    ) {
+      appState.pendingDrop = null;
+    }
+
     return { stop, index: stopIndex };
   }
 
@@ -488,18 +570,38 @@
       stop.posterior.mean < min.posterior.mean ? stop : min,
     );
 
-    setTimeout(() => {
-      const confirmed = window.confirm(
-        `To extend your stay, drop the lowest-rated remaining store:\n\n${lowestScoringStop.name} (Posterior μ: ${lowestScoringStop.posterior.mean.toFixed(
-          2,
-        )})\n\nDrop this store?`,
-      );
+    appState.pendingDrop = {
+      stopId: lowestScoringStop.id,
+      reason: 'overrun-drop-lowest',
+    };
 
-      if (confirmed) {
-        dropStopById(lowestScoringStop.id, 'overrun-drop-lowest');
-      }
-      advanceToNextStore();
-    }, 500);
+    renderAll();
+  }
+
+  function confirmPendingDrop() {
+    const pendingDrop = appState.pendingDrop;
+    if (!pendingDrop) {
+      return;
+    }
+
+    const stopId = pendingDrop.stopId ?? pendingDrop.id;
+    const reason = pendingDrop.reason ?? 'pending-drop';
+
+    if (stopId != null) {
+      dropStopById(stopId, reason);
+    }
+
+    appState.pendingDrop = null;
+    advanceToNextStore();
+  }
+
+  function cancelPendingDrop() {
+    if (!appState.pendingDrop) {
+      return;
+    }
+
+    appState.pendingDrop = null;
+    advanceToNextStore();
   }
 
   function advanceToNextStore() {
@@ -557,6 +659,9 @@
         if (!stop || stop.status !== 'tovisit') {
           return;
         }
+        const matchedPendingDrop =
+          !!appState.pendingDrop &&
+          String(appState.pendingDrop.stopId ?? appState.pendingDrop.id) === stopId;
         const confirmed = window.confirm(
           `Drop ${stop.name}?\n\nThis will mark the store as dropped.`,
         );
@@ -565,9 +670,15 @@
         }
         const dropResult = dropStopById(stopId, 'manual-drop');
         if (!dropResult) {
+          if (matchedPendingDrop) {
+            appState.pendingDrop = null;
+            advanceToNextStore();
+          }
           return;
         }
-        if (dropResult.index === appState.currentIndex) {
+        if (matchedPendingDrop) {
+          advanceToNextStore();
+        } else if (dropResult.index === appState.currentIndex) {
           advanceToNextStore();
         } else {
           renderAll();


### PR DESCRIPTION
## Summary
- capture the lowest-rated remaining store in `appState.pendingDrop` when extending a stay and re-render the UI instead of prompting with `window.confirm`
- surface a pending-drop banner in the recommendation display with store details and explicit Drop/Keep controls wired to confirmation handlers
- update manual drop handling so resolving the pending drop is required before advancing to the next store

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf3c39eec883288196a6a965e7fe1e