### PR TITLE
Polish dashboard glossary styling

### DIFF
--- a/src/io/templates/day-of-style.mustache
+++ b/src/io/templates/day-of-style.mustache
@@ -495,4 +495,133 @@ input[type='radio'].text-teal-600 {
 .recommendation-leave {
   color: #be123c;
 }
+
+.dashboard-glossary {
+  background: #ffffff;
+  border: 1px solid var(--stone-200);
+  border-radius: 1.5rem;
+  padding: clamp(1.75rem, 2.5vw + 1rem, 3rem);
+  box-shadow: 0 18px 36px rgba(28, 25, 23, 0.08);
+}
+
+.glossary-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.glossary-heading {
+  font-size: clamp(1.75rem, 2.2vw + 1.5rem, 2.5rem);
+  font-weight: 600;
+  color: var(--stone-900);
+}
+
+.glossary-subheading {
+  max-width: 36rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--stone-500);
+}
+
+@media (min-width: 768px) {
+  .glossary-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+}
+
+.glossary-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.glossary-entry {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  background: var(--stone-50);
+  border: 1px solid var(--stone-200);
+  border-radius: 1.15rem;
+  box-shadow: 0 12px 30px rgba(28, 25, 23, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  overflow: hidden;
+}
+
+.glossary-entry:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 38px rgba(28, 25, 23, 0.1);
+}
+
+.glossary-entry__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.glossary-entry__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--stone-900);
+}
+
+.glossary-entry__description {
+  font-size: 0.975rem;
+  line-height: 1.65;
+  color: var(--stone-600);
+}
+
+.glossary-entry__callouts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.glossary-entry__callout {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--stone-200);
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgba(28, 25, 23, 0.08);
+}
+
+.glossary-entry__callout--high {
+  background: #eef6f2;
+  border-color: #d5e7dc;
+}
+
+.glossary-entry__callout--low {
+  background: #f8efef;
+  border-color: #ebd6d7;
+}
+
+.glossary-entry__callout-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.glossary-entry__callout--high .glossary-entry__callout-label {
+  color: var(--teal-800);
+}
+
+.glossary-entry__callout--low .glossary-entry__callout-label {
+  color: var(--stone-700);
+}
+
+.glossary-entry__callout p {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--stone-700);
+}
 </style>

--- a/src/io/templates/day-of.mustache
+++ b/src/io/templates/day-of.mustache
@@ -186,99 +186,196 @@
           </div>
         </section>
       </main>
-      <section class="mt-10 bg-white p-6 rounded-lg shadow-sm">
-        <h2 class="text-2xl font-bold mb-6 text-stone-900">Dashboard Glossary</h2>
-
-        <!-- Glossary Grid -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <!-- Total Stores -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Total Stores</h3>
-            <p class="text-sm text-stone-600 mt-1">Shows how many store stops are on the agenda so you can gauge the full workload and pacing for the day.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high count suggests a long day, which can be draining if your resources are limited.</li>
-              <li>A low count means a more manageable day, making it easier to stay focused and on schedule.</li>
-            </ul>
+      <section class="mt-10">
+        <div class="dashboard-glossary">
+          <div class="glossary-header">
+            <h2 class="glossary-heading">Dashboard Glossary</h2>
+            <p class="glossary-subheading">
+              Use this reference to decode each metric on the dashboard so you can make confident, in-the-moment decisions during a run.
+            </p>
           </div>
 
-          <!-- Stores Visited -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Stores Visited</h3>
-            <p class="text-sm text-stone-600 mt-1">Tracks how many stores have been worked so you can judge progress against the plan and momentum of the run.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high number shows you're on track and keeping pace with your plan.</li>
-              <li>A low number can be a red flag if many stops remain, indicating you're behind schedule.</li>
-            </ul>
-          </div>
+          <!-- Glossary Grid -->
+          <div class="glossary-grid">
+            <!-- Total Stores -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Total Stores</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Shows how many store stops are on the agenda so you can gauge the full workload and pacing for the day.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>A long day ahead that can be draining if your resources are limited.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>A more manageable itinerary that makes it easier to stay focused and on schedule.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Avg. J-Score -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Avg. J-Score</h3>
-            <p class="text-sm text-stone-600 mt-1">Summarizes the average anticipated value for your entire itinerary. It's the average of your personal 'want-to-go' scores, giving you a baseline for the day's potential.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high average suggests a promising route filled with valuable stops, which is a great boost for morale.</li>
-              <li>A low average means you might be looking for needles in a haystack, making it tougher to prioritize.</li>
-            </ul>
-          </div>
+            <!-- Stores Visited -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Stores Visited</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Tracks how many stores have been worked so you can judge progress against the plan and momentum of the run.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>You're on pace and keeping momentum with the route plan.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>A signal you might be falling behind, especially if many stops remain.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Remaining Posterior μ -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Remaining Posterior μ</h3>
-            <p class="text-sm text-stone-600 mt-1">Estimates the updated anticipated value of the stores you haven't hit yet, guiding whether to push forward or start wrapping.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high score means the rest of your trip still looks highly promising—a great reason to keep pushing forward.</li>
-              <li>A low score suggests the remaining stops may not offer much value, which could be a signal to wrap up.</li>
-            </ul>
-          </div>
+            <!-- Avg. J-Score -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Avg. J-Score</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Summarizes the average anticipated value for your entire itinerary—the mean of your personal &ldquo;want-to-go&rdquo; scores for each store.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>The route is packed with promising stops that can keep morale high.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>You're likely hunting for needles in a haystack, so prioritization becomes critical.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Remaining Uncertainty σ -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Remaining Uncertainty σ</h3>
-            <p class="text-sm text-stone-600 mt-1">Shows how unknown the untouched stores still are so you know if surprises—good or bad—are likely.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high value means the remaining stores are wild cards; expect the unexpected.</li>
-              <li>A low value means the remaining stops are predictable, giving you more confidence to stick to your plan.</li>
-            </ul>
-          </div>
+            <!-- Remaining Posterior μ -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Remaining Posterior μ</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Estimates the updated anticipated value of the stores you haven't hit yet, guiding whether to push forward or start wrapping up.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>The rest of the run still looks highly promising, so keep pressing.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>The remaining stops may not offer much upside, signaling it could be time to wind down.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Current Posterior μ -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Current Posterior μ</h3>
-            <p class="text-sm text-stone-600 mt-1">Captures the best estimate of the current store’s quality, telling you if sticking around is likely to pay off.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high value is a green light, suggesting this store is living up to its potential—a good signal to stay engaged.</li>
-              <li>A low value suggests this stop may be a bust, favoring a quick exit.</li>
-            </ul>
-          </div>
+            <!-- Remaining Uncertainty σ -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Remaining Uncertainty σ</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Shows how unknown the untouched stores still are so you know if surprises&mdash;good or bad&mdash;are likely.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>The remaining stores are wild cards&mdash;expect the unexpected.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>Those stops are predictable, giving you more confidence to stick with the plan.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Current Uncertainty σ -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Current Uncertainty σ</h3>
-            <p class="text-sm text-stone-600 mt-1">Measures how confident you are about the current store’s read so you know whether to trust the estimate.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high value means you don't have enough data yet; the intel on this store is still fuzzy.</li>
-              <li>A low value means you have solid evidence, making it easy to make a decisive choice.</li>
-            </ul>
-          </div>
+            <!-- Current Posterior μ -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Current Posterior μ</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Captures the best estimate of the current store&rsquo;s quality, telling you if sticking around is likely to pay off.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>A green light that the store is living up to its potential&mdash;stay engaged.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>A hint this stop may be a bust, making a quick exit more appealing.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Current Upper Confidence Bound (UCB) Score -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Current Upper Confidence Bound (UCB) Score</h3>
-            <p class="text-sm text-stone-600 mt-1">Blends the current store's quality and risk so you know the upside if you keep working it right now.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high score means there's a strong potential for a big find, which could be a good reason to commit more time.</li>
-              <li>A low score suggests this stop has limited upside, making a quick exit the better option.</li>
-            </ul>
-          </div>
+            <!-- Current Uncertainty σ -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Current Uncertainty σ</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Measures how confident you are about the current store&rsquo;s read so you know whether to trust the estimate.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>You still don&rsquo;t have enough intel&mdash;keep collecting data.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>The read is solid, so it&rsquo;s easier to make a decisive call.</p>
+                </div>
+              </div>
+            </article>
 
-          <!-- Remaining Upper Confidence Bound (UCB) Score -->
-          <div>
-            <h3 class="font-semibold text-lg text-stone-800">Remaining Upper Confidence Bound (UCB) Score</h3>
-            <p class="text-sm text-stone-600 mt-1">Combines the expected quality and risk of the untouched stores to show the upside left in the route.</p>
-            <ul class="list-disc list-inside text-xs text-stone-500 mt-2 space-y-2">
-              <li>A high score indicates the rest of the trip has major potential, providing great motivation to keep pushing forward.</li>
-              <li>A low score means there's limited upside left in the itinerary, which could be a factor in deciding to end the day early.</li>
-            </ul>
+            <!-- Current Upper Confidence Bound (UCB) Score -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Current Upper Confidence Bound (UCB) Score</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Blends the current store&rsquo;s quality and risk so you understand the upside if you keep working it right now.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>There&rsquo;s strong potential for a big find, making it worth more of your time.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>The upside is limited, so moving on could be the smarter play.</p>
+                </div>
+              </div>
+            </article>
+
+            <!-- Remaining Upper Confidence Bound (UCB) Score -->
+            <article class="glossary-entry">
+              <header class="glossary-entry__heading">
+                <h3 class="glossary-entry__title">Remaining Upper Confidence Bound (UCB) Score</h3>
+              </header>
+              <p class="glossary-entry__description">
+                Combines the expected quality and risk of the untouched stores to show the upside left in the route.
+              </p>
+              <div class="glossary-entry__callouts">
+                <div class="glossary-entry__callout glossary-entry__callout--high">
+                  <span class="glossary-entry__callout-label">High</span>
+                  <p>The rest of the itinerary still has major potential, so stay aggressive.</p>
+                </div>
+                <div class="glossary-entry__callout glossary-entry__callout--low">
+                  <span class="glossary-entry__callout-label">Low</span>
+                  <p>Limited upside remains, which could be a cue to wrap the day early.</p>
+                </div>
+              </div>
+            </article>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the glossary markup with structured cards that keep each metric and its high/low guidance bundled together
- add dedicated glossary styles for the new card layout while stacking the callouts vertically with pale green/red tints and relying on clean rounded borders instead of a gradient accent

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cf638327c08328995f8c8b2be21327