### PR TITLE
Show initial score context in itinerary score cards

### DIFF
--- a/docs/day-of-support-app.js
+++ b/docs/day-of-support-app.js
@@ -182,6 +182,7 @@
       }`;
       const posteriorMean = stop.posterior ? stop.posterior.mean.toFixed(2) : formatScore(stop.score);
       const posteriorStd = stop.posterior ? stop.posterior.std.toFixed(2) : '0.00';
+      const initialScore = formatScore(stop.score);
       const statusLabel =
         stop.status === 'visited'
           ? `Visited – ${stop.mqa ?? 'n/a'}`
@@ -196,7 +197,16 @@
           </div>
           <div class="text-right">
             <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">${posteriorMean}</p>
-            <p class="text-xs text-stone-500">±${posteriorStd}</p>
+            <div class="mt-2 space-y-1 leading-tight">
+              <div>
+                <p class="text-xs uppercase tracking-wide text-stone-600">Uncertainty</p>
+                <p class="text-xs text-stone-600">±${posteriorStd}</p>
+              </div>
+              <div>
+                <p class="text-xs uppercase tracking-wide text-stone-600">Initial Score</p>
+                <p class="text-xs text-stone-600">${initialScore}</p>
+              </div>
+            </div>
           </div>
         </div>
       `;

--- a/src/io/templates/day-of-script.mustache
+++ b/src/io/templates/day-of-script.mustache
@@ -236,6 +236,7 @@
       }`;
       const posteriorMean = stop.posterior ? stop.posterior.mean.toFixed(2) : formatScore(stop.score);
       const posteriorStd = stop.posterior ? stop.posterior.std.toFixed(2) : '0.00';
+      const initialScore = formatScore(stop.score);
       const statusLabel =
         stop.status === 'visited'
           ? `Visited – ${stop.mqa ?? 'n/a'}`
@@ -255,10 +256,19 @@
             <p class="font-semibold">${nameMarkup}</p>
             <p class="text-xs text-stone-500">${statusLabel}</p>
           </div>
-          <div class="flex flex-col items-end text-right gap-1">
-            <div>
+          <div class="flex flex-col items-end text-right gap-2">
+            <div class="text-right">
               <p class="font-mono text-sm bg-stone-200 text-stone-700 px-2 py-1 rounded">${posteriorMean}</p>
-              <p class="text-xs text-stone-500">±${posteriorStd}</p>
+              <div class="mt-2 space-y-1 leading-tight">
+                <div>
+                  <p class="text-xs uppercase tracking-wide text-stone-600">Uncertainty</p>
+                  <p class="text-xs text-stone-600">±${posteriorStd}</p>
+                </div>
+                <div>
+                  <p class="text-xs uppercase tracking-wide text-stone-600">Initial Score</p>
+                  <p class="text-xs text-stone-600">${initialScore}</p>
+                </div>
+              </div>
             </div>
             ${dropButtonHtml}
           </div>


### PR DESCRIPTION
## Summary
- ensure the itinerary script template renders the labelled uncertainty and initial score details for each stop so the UI matches the docs change
- update the itinerary template and docs script to style the uncertainty and initial score labels with the requested small uppercase treatment

## Testing
- npm run lint *(fails: parserOptions.project has been provided for @typescript-eslint/parser; tests/*.test.ts are outside the configured project)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6fdb03048328bd8de67d8e961faf