### PR TITLE
Use Haversine distance for kNN smoothing instead of Euclidean

### DIFF
--- a/packages/atlas-python/src/atlas/scoring/posterior.py
+++ b/packages/atlas-python/src/atlas/scoring/posterior.py
@@ -276,6 +276,30 @@ def _infer_coordinate_columns(frame: pd.DataFrame) -> tuple[str | None, str | No
     return None, None
 
 
+def _haversine_distances(anchor_coords: np.ndarray, point: np.ndarray) -> np.ndarray:
+    """Return great-circle distances in km from each row of *anchor_coords* to *point*.
+
+    Parameters
+    ----------
+    anchor_coords:
+        Shape ``(n, 2)`` array of ``[lat, lon]`` pairs in decimal degrees.
+    point:
+        Shape ``(2,)`` array of ``[lat, lon]`` in decimal degrees.
+    """
+    R = 6371.0  # Earth's mean radius in km
+
+    lat1 = np.radians(anchor_coords[:, 0])
+    lon1 = np.radians(anchor_coords[:, 1])
+    lat2 = np.radians(point[0])
+    lon2 = np.radians(point[1])
+
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+
+    a = np.sin(dlat / 2.0) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2.0) ** 2
+    return 2.0 * R * np.arcsin(np.sqrt(np.clip(a, 0.0, 1.0)))
+
+
 def _knn_smooth_sparse_predictions(
     stores: pd.DataFrame,
     theta: np.ndarray,
@@ -304,7 +328,7 @@ def _knn_smooth_sparse_predictions(
     smoothed_value = value.copy()
 
     for idx in np.where(mask_sparse)[0]:
-        distances = np.sqrt(np.sum((anchor_coords - coords[idx]) ** 2, axis=1))
+        distances = _haversine_distances(anchor_coords, coords[idx])
         if len(distances) == 0:
             continue
         neighbour_count = min(k, len(distances))

--- a/packages/atlas-python/tests/test_posterior_scoring.py
+++ b/packages/atlas-python/tests/test_posterior_scoring.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from atlas.scoring import PosteriorPipeline
+from atlas.scoring.posterior import _haversine_distances, _knn_smooth_sparse_predictions
 
 
 def _make_store_frame() -> pd.DataFrame:
@@ -146,3 +147,140 @@ def test_ecdf_quantile_is_reused_between_runs(tmp_path: Path) -> None:
     sorted_quantiles = predictions.iloc[order]["ECDF_q"].to_numpy()
     assert np.all(sorted_quantiles[:-1] <= sorted_quantiles[1:] + 1e-8)
 
+
+# ---------------------------------------------------------------------------
+# Haversine distance tests (Issue 3 / Tier 2.1)
+# ---------------------------------------------------------------------------
+
+
+def test_haversine_distances_known_values() -> None:
+    """Haversine distances match known city-pair values within 5 km."""
+    # Detroit (42.33, -83.05) → Cleveland (41.50, -81.69): ~146 km as the crow flies
+    detroit = np.array([[42.33, -83.05]])
+    cleveland = np.array([41.50, -81.69])
+    dist = _haversine_distances(detroit, cleveland)
+    assert dist.shape == (1,)
+    assert abs(dist[0] - 146.0) < 5.0  # within 5 km of straight-line distance
+
+    # Detroit → Pittsburgh (40.44, -79.99): ~331 km as the crow flies
+    pittsburgh = np.array([40.44, -79.99])
+    dist2 = _haversine_distances(detroit, pittsburgh)
+    assert abs(dist2[0] - 331.0) < 10.0
+
+    # Same point → 0
+    zero = _haversine_distances(detroit, detroit[0])
+    assert abs(zero[0]) < 0.01
+
+
+def test_haversine_distances_east_west_vs_north_south() -> None:
+    """Haversine corrects the Euclidean degree-distortion.
+
+    At ~42° N latitude, 1° of longitude ≈ 82 km and 1° of latitude ≈ 111 km.
+    A point displaced 1° east is closer than a point displaced 1° north, but
+    Euclidean distance on raw degrees treats them as equal.
+
+    Haversine must report the east-displaced point as closer.
+    """
+    origin = np.array([[42.0, -83.0]])
+    north_1deg = np.array([43.0, -83.0])  # 1° N  ≈ 111 km
+    east_1deg = np.array([42.0, -82.0])   # 1° E  ≈  82 km at 42° N
+
+    dist_north = _haversine_distances(origin, north_1deg)[0]
+    dist_east = _haversine_distances(origin, east_1deg)[0]
+
+    # Haversine knows east-displacement is shorter at this latitude
+    assert dist_east < dist_north, (
+        f"Expected east-displacement ({dist_east:.1f} km) < north-displacement "
+        f"({dist_north:.1f} km) at 42° N — Euclidean on degrees would call them equal"
+    )
+
+    # Rough magnitude check: 1° lon at 42° N ≈ 82 km, 1° lat ≈ 111 km
+    assert 75 < dist_east < 90
+    assert 108 < dist_north < 114
+
+
+def test_knn_smooth_uses_haversine_neighbor_selection() -> None:
+    """kNN smoother weights by km, not by degree-distance.
+
+    Geometry at ~42° N latitude:
+      - 1° of latitude  ≈ 111 km (north-south)
+      - 1° of longitude ≈  82 km (east-west, shrinks with cos(lat))
+
+    Anchor A is 1° west  of sparse store D  → ~82 km  (closer in km)
+    Anchor B is 1° north of sparse store D  → ~111 km (farther in km)
+
+    With Euclidean distance on raw degrees both anchors are exactly 1° away,
+    so the weights are equal and the smoothed value is 5.5 (midpoint of 1 and 10).
+
+    With Haversine, A is meaningfully closer → its weight is larger → the
+    smoothed value is pulled above 5.5 toward A's theta of 10.
+    """
+    # Sparse store D at 42° N, −83° E
+    # Anchor A: 1° west  — same latitude, closer in km
+    # Anchor B: 1° north — same longitude, farther in km
+    stores = pd.DataFrame(
+        {
+            "StoreId": ["A", "B", "D"],
+            "Latitude": [42.0, 43.0, 42.0],
+            "Longitude": [-84.0, -83.0, -83.0],
+        }
+    )
+
+    theta = np.array([10.0, 1.0, 0.0])
+    value = np.array([5.0, 1.0, 0.0])
+    visits = np.array([1, 1, 0])  # D is sparse
+
+    smoothed_theta, _ = _knn_smooth_sparse_predictions(
+        stores, theta, value, visits, k=2, smoothing_factor=1.0
+    )
+
+    smoothed_d = smoothed_theta[2]
+
+    # Euclidean on degrees: equal weights → result = 5.5 exactly
+    # Haversine: A is closer (~82 km vs ~111 km) → result > 5.5
+    assert smoothed_d > 5.5, (
+        f"With Haversine, west-displaced anchor A (~82 km) should outweigh "
+        f"north-displaced anchor B (~111 km); expected > 5.5, got {smoothed_d:.4f}"
+    )
+    # Sanity bounds: should be between 5.5 and 10.0
+    assert smoothed_d < 10.0
+
+
+def test_knn_smooth_cross_metro_prefers_nearer_city() -> None:
+    """Across metros, kNN smoother selects the geographically nearest anchor.
+
+    Scenario: sparse store in Pittsburgh (40.44, -79.99).
+    Two anchors:
+      - Detroit  (42.33, -83.05): ~355 km
+      - Philadelphia (39.95, -75.16): ~490 km
+    With k=1 and smoothing_factor=1.0 the sparse store should be 100%
+    smoothed toward Detroit (the closer city), not Philadelphia.
+
+    Euclidean on raw degrees would give:
+      Detroit:      sqrt((2.11)^2 + (3.06)^2) ≈ 3.72°
+      Philadelphia: sqrt((0.49)^2 + (4.83)^2) ≈ 4.86°
+    So Euclidean also picks Detroit here — but the margin is realistic.
+    The haversine distances are roughly:
+      Detroit ≈ 355 km, Philadelphia ≈ 490 km
+    This test documents the expected cross-metro behaviour.
+    """
+    stores = pd.DataFrame(
+        {
+            "StoreId": ["Detroit", "Philly", "Pittsburgh"],
+            "Latitude": [42.33, 39.95, 40.44],
+            "Longitude": [-83.05, -75.16, -79.99],
+        }
+    )
+
+    theta = np.array([8.0, 2.0, 0.0])
+    value = np.array([4.0, 2.0, 0.0])
+    visits = np.array([5, 5, 0])
+
+    smoothed_theta, _ = _knn_smooth_sparse_predictions(
+        stores, theta, value, visits, k=1, smoothing_factor=1.0
+    )
+
+    # Pittsburgh should be smoothed 100% toward Detroit (closer), not Philly
+    assert smoothed_theta[2] == pytest.approx(8.0, abs=0.01), (
+        f"Pittsburgh theta should match Detroit's (8.0) with k=1; got {smoothed_theta[2]:.3f}"
+    )


### PR DESCRIPTION
## Summary
Replace Euclidean distance calculations with Haversine (great-circle) distance in the kNN smoother for sparse store predictions. This corrects for the geographic distortion that occurs when using raw latitude/longitude degrees as Euclidean coordinates.

## Key Changes
- **Added `_haversine_distances()` function**: Computes great-circle distances in kilometers between anchor coordinates and a target point using the Haversine formula. This accounts for Earth's curvature and the latitude-dependent shrinking of longitude degrees.
- **Updated `_knn_smooth_sparse_predictions()`**: Changed from Euclidean distance on raw degrees to Haversine distance for neighbor selection and weighting. This ensures that geographic proximity is measured in actual kilometers rather than degree-space.
- **Added comprehensive test coverage**: 
  - `test_haversine_distances_known_values()`: Validates against real city-pair distances (Detroit-Cleveland, Detroit-Pittsburgh)
  - `test_haversine_distances_east_west_vs_north_south()`: Verifies that Haversine correctly accounts for latitude-dependent longitude compression
  - `test_knn_smooth_uses_haversine_neighbor_selection()`: Confirms that kNN smoothing weights anchors by actual km distance, not degree distance
  - `test_knn_smooth_cross_metro_prefers_nearer_city()`: Tests cross-metro behavior with realistic city coordinates

## Implementation Details
- Haversine formula uses Earth's mean radius of 6371 km
- Distance calculations are numerically stable with clipping to handle floating-point errors
- The change is backward-compatible; only the distance metric changes, not the API or smoothing logic

https://claude.ai/code/session_011wNLYk4GyTQYjsmGcT5fp2