### PR TITLE
Fix Google Places API nearby_search to use locationBias instead of locationRestriction

### DIFF
--- a/packages/rustbelt-discover/src/discover/places.py
+++ b/packages/rustbelt-discover/src/discover/places.py
@@ -136,7 +136,9 @@ class GooglePlacesClient:
 
             body: dict = {
                 "textQuery": search_text,
-                "locationRestriction": {
+                # Text Search (New) only accepts a circle under locationBias;
+                # locationRestriction is rectangle-only and 400s on a circle.
+                "locationBias": {
                     "circle": {
                         "center": {"latitude": lat, "longitude": lon},
                         "radius": radius_meters,

--- a/packages/rustbelt-discover/tests/test_places.py
+++ b/packages/rustbelt-discover/tests/test_places.py
@@ -2,7 +2,47 @@
 
 import pytest
 
-from discover.places import _parse_cid, _parse_us_address
+from discover.places import GooglePlacesClient, _parse_cid, _parse_us_address
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class _RecordingSession:
+    """Captures the request kwargs of the last call and returns a canned page."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return _FakeResponse(self._payload)
+
+
+class TestNearbySearchRequestShape:
+    def test_uses_location_bias_circle_not_restriction(self):
+        # Text Search (New) rejects a circle under locationRestriction (400);
+        # a circle is only valid under locationBias. Guard against regressing.
+        session = _RecordingSession({"places": []})
+        client = GooglePlacesClient(session=session, api_key="k")
+
+        client.nearby_search(
+            lat=37.27, lon=-79.94, radius_meters=48280.0, search_text="thrift store"
+        )
+
+        body = session.calls[0]["json"]
+        assert "locationBias" in body
+        assert "locationRestriction" not in body
+        assert body["locationBias"]["circle"]["radius"] == 48280.0
+        assert body["textQuery"] == "thrift store"
 
 
 class TestParseCid:


### PR DESCRIPTION
## Summary
Fixed the `nearby_search` method in `GooglePlacesClient` to use `locationBias` instead of `locationRestriction` for circular location filtering, which aligns with the Google Places API (New) specification.

## Key Changes
- Changed the `nearby_search` request body to use `locationBias` with a circle instead of `locationRestriction`
- Added clarifying comments explaining that the Text Search (New) API only accepts circles under `locationBias`, not `locationRestriction`
- Added comprehensive test coverage (`TestNearbySearchRequestShape`) to verify the request shape and prevent regression
- Created test utilities (`_FakeResponse` and `_RecordingSession`) to enable request inspection in tests

## Implementation Details
The Google Places API (New) has specific requirements for location filtering:
- `locationRestriction` only accepts rectangles and returns a 400 error when given a circle
- `locationBias` accepts circles and is the correct parameter for circular location filtering

The test validates that:
- The request uses `locationBias` (not `locationRestriction`)
- The circle radius is correctly set
- The text query parameter is included

https://claude.ai/code/session_01HRnE7p8VVxcf8Y1LfKcY3m